### PR TITLE
Support complete on another editors- Add snippet support - Fix test

### DIFF
--- a/apps/elixir_ls_utils/.gitignore
+++ b/apps/elixir_ls_utils/.gitignore
@@ -18,3 +18,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore Tests tmp
+/test/tmp

--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -8,6 +8,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
   text before the cursor so we can filter out suggestions that are not relevant.
   """
 
+  alias ElixirLS.LanguageServer.Providers.Completion.Snippets
+
   def completion(text, line, character, snippets_supported) do
     text_before_cursor =
       text
@@ -40,7 +42,15 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
 
     items =
       if snippets_supported do
-        items
+        items =
+          Enum.reject(
+            items,
+            &Enum.any?(Snippets.get_snippets(), fn %{"label" => label} ->
+              String.starts_with?(&1["label"], label)
+            end)
+          )
+
+        items ++ Snippets.get_snippets()
       else
         Enum.map(items, &remove_snippets/1)
       end

--- a/apps/language_server/lib/language_server/providers/completion/snippets.ex
+++ b/apps/language_server/lib/language_server/providers/completion/snippets.ex
@@ -1,0 +1,277 @@
+defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
+  @moduledoc """
+  Snippets module provider
+
+  Extracted from https://github.com/fr1zle/vscode-elixir/blob/master/snippets/snippets.json
+  """
+  @snippets [
+    %{
+      "label" => "case",
+      # Function
+      "kind" => 3,
+      "detail" => "case",
+      "documentation" => "case",
+      "insertText" => "case $1 do\n\t$2 ->\n\t\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "cond",
+      # Function
+      "kind" => 3,
+      "detail" => "cond",
+      "documentation" => "cond",
+      "insertText" => "cond do\n\t$1 ->\n\t\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "def",
+      # Function
+      "kind" => 3,
+      "detail" => "def",
+      "documentation" => "def",
+      "insertText" => "def $1 do\n\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "test",
+      # Function
+      "kind" => 3,
+      "detail" => "test",
+      "documentation" => "test",
+      "insertText" => "test $1 do\n\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "describe",
+      # Function
+      "kind" => 3,
+      "detail" => "describe",
+      "documentation" => "describe",
+      "insertText" => "describe $1 do\n\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defcallback",
+      # Function
+      "kind" => 3,
+      "detail" => "defcallback",
+      "documentation" => "defcallback",
+      "insertText" => "defcallback $1 :: $0",
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defdelegate",
+      # Function
+      "kind" => 3,
+      "detail" => "defdelegate",
+      "documentation" => "defdelegate",
+      "insertText" => "defdelegate $1 to: $0",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defexception",
+      # Function
+      "kind" => 3,
+      "detail" => "defexception",
+      "documentation" => "defexception",
+      "insertText" => "defexception [${1::message}]",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defimpl",
+      # Function
+      "kind" => 3,
+      "detail" => "defimpl",
+      "documentation" => "defimpl",
+      "insertText" => "defimpl $1, for: $2 do\n  $0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defmacro",
+      # Function
+      "kind" => 3,
+      "detail" => "defmacro",
+      "documentation" => "defmacro",
+      "insertText" => "defmacro $1 do\n\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defmacrocallback",
+      # Function
+      "kind" => 3,
+      "detail" => "defmacrocallback",
+      "documentation" => "defmacrocallback",
+      "insertText" => "defmacrocallback $1 :: $0",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defmacrop",
+      # Function
+      "kind" => 3,
+      "detail" => "defmacrop",
+      "documentation" => "defmacrop",
+      "insertText" => "defmacrop $1 do\n\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defmodule",
+      # Function
+      "kind" => 3,
+      "detail" => "defmodule",
+      "documentation" => "defmodule",
+      "insertText" => "defmodule $1 do\n\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defp",
+      # Function
+      "kind" => 3,
+      "detail" => "defp",
+      "documentation" => "defp",
+      "insertText" => "defp $1 do\n\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defprotocol",
+      # Function
+      "kind" => 3,
+      "detail" => "defprotocol",
+      "documentation" => "defprotocol",
+      "insertText" => "defprotocol $1 do\n  $0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "defstruct",
+      # Function
+      "kind" => 3,
+      "detail" => "defstruct",
+      "documentation" => "defstruct",
+      "insertText" => "defstruct $1: $2",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "do",
+      # Function
+      "kind" => 3,
+      "detail" => "do",
+      "documentation" => "do",
+      "insertText" => "do\n\t$0\nend",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "@doc",
+      # Function
+      "kind" => 3,
+      "detail" => "@doc",
+      "documentation" => "@doc",
+      "insertText" => "@doc \"\"\"\n$0\n\"\"\"",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "i",
+      # Function
+      "kind" => 3,
+      "detail" => "i",
+      "documentation" => "i",
+      "insertText" => "inspect($0)",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "ii",
+      # Function
+      "kind" => 3,
+      "detail" => "ii",
+      "documentation" => "ii",
+      "insertText" => "IO.inspect($0)",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "@moduledoc",
+      # Function
+      "kind" => 3,
+      "detail" => "@moduledoc",
+      "documentation" => "@moduledoc",
+      "insertText" => "@moduledoc \"\"\"\n$0\n\"\"\"",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "@spec",
+      # Function
+      "kind" => 3,
+      "detail" => "@spec",
+      "documentation" => "@spec",
+      "insertText" => "@spec $0",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "receive",
+      # Function
+      "kind" => 3,
+      "detail" => "receive",
+      "documentation" => "receive",
+      "insertText" =>
+        "receive do\n\t${1:{${2::message_type}, ${3:value}\\}} ->\n    ${0:# code}\nend\n",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    },
+    %{
+      "label" => "require",
+      # Function
+      "kind" => 3,
+      "detail" => "require",
+      "documentation" => "require",
+      "insertText" => "require $0",
+      # snippet
+      "insertTextFormat" => 2,
+      "sortText" => "0"
+    }
+  ]
+
+  def get_snippets do
+    @snippets
+  end
+end

--- a/apps/language_server/lib/language_server/providers/completion/snippets.ex
+++ b/apps/language_server/lib/language_server/providers/completion/snippets.ex
@@ -7,8 +7,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
   @snippets [
     %{
       "label" => "case",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "case",
       "documentation" => "case",
       "insertText" => "case $1 do\n\t$2 ->\n\t\t$0\nend",
@@ -18,8 +18,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "cond",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "cond",
       "documentation" => "cond",
       "insertText" => "cond do\n\t$1 ->\n\t\t$0\nend",
@@ -29,8 +29,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "def",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "def",
       "documentation" => "def",
       "insertText" => "def $1 do\n\t$0\nend",
@@ -40,8 +40,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "test",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "test",
       "documentation" => "test",
       "insertText" => "test $1 do\n\t$0\nend",
@@ -51,8 +51,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "describe",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "describe",
       "documentation" => "describe",
       "insertText" => "describe $1 do\n\t$0\nend",
@@ -62,8 +62,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defcallback",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defcallback",
       "documentation" => "defcallback",
       "insertText" => "defcallback $1 :: $0",
@@ -72,8 +72,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defdelegate",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defdelegate",
       "documentation" => "defdelegate",
       "insertText" => "defdelegate $1 to: $0",
@@ -83,8 +83,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defexception",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defexception",
       "documentation" => "defexception",
       "insertText" => "defexception [${1::message}]",
@@ -94,8 +94,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defimpl",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defimpl",
       "documentation" => "defimpl",
       "insertText" => "defimpl $1, for: $2 do\n  $0\nend",
@@ -105,8 +105,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defmacro",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defmacro",
       "documentation" => "defmacro",
       "insertText" => "defmacro $1 do\n\t$0\nend",
@@ -116,8 +116,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defmacrocallback",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defmacrocallback",
       "documentation" => "defmacrocallback",
       "insertText" => "defmacrocallback $1 :: $0",
@@ -127,8 +127,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defmacrop",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defmacrop",
       "documentation" => "defmacrop",
       "insertText" => "defmacrop $1 do\n\t$0\nend",
@@ -138,8 +138,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defmodule",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defmodule",
       "documentation" => "defmodule",
       "insertText" => "defmodule $1 do\n\t$0\nend",
@@ -149,8 +149,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defp",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defp",
       "documentation" => "defp",
       "insertText" => "defp $1 do\n\t$0\nend",
@@ -160,8 +160,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defprotocol",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defprotocol",
       "documentation" => "defprotocol",
       "insertText" => "defprotocol $1 do\n  $0\nend",
@@ -171,8 +171,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "defstruct",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "defstruct",
       "documentation" => "defstruct",
       "insertText" => "defstruct $1: $2",
@@ -182,8 +182,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "do",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "do",
       "documentation" => "do",
       "insertText" => "do\n\t$0\nend",
@@ -193,8 +193,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "@doc",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "@doc",
       "documentation" => "@doc",
       "insertText" => "@doc \"\"\"\n$0\n\"\"\"",
@@ -204,8 +204,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "i",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "i",
       "documentation" => "i",
       "insertText" => "inspect($0)",
@@ -215,8 +215,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "ii",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "ii",
       "documentation" => "ii",
       "insertText" => "IO.inspect($0)",
@@ -226,8 +226,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "@moduledoc",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "@moduledoc",
       "documentation" => "@moduledoc",
       "insertText" => "@moduledoc \"\"\"\n$0\n\"\"\"",
@@ -237,8 +237,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "@spec",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "@spec",
       "documentation" => "@spec",
       "insertText" => "@spec $0",
@@ -248,8 +248,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "receive",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "receive",
       "documentation" => "receive",
       "insertText" =>
@@ -260,8 +260,8 @@ defmodule ElixirLS.LanguageServer.Providers.Completion.Snippets do
     },
     %{
       "label" => "require",
-      # Function
-      "kind" => 3,
+      # Snippet
+      "kind" => 15,
       "detail" => "require",
       "documentation" => "require",
       "insertText" => "require $0",

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -20,12 +20,12 @@ defmodule ElixirLS.LanguageServer.Server do
   alias ElixirLS.LanguageServer.{SourceFile, Build, Protocol, JsonRpc, Dialyzer}
 
   alias ElixirLS.LanguageServer.Providers.{
-          Completion,
-          Hover,
-          Definition,
-          Formatting,
-          SignatureHelp
-        }
+    Completion,
+    Hover,
+    Definition,
+    Formatting,
+    SignatureHelp
+  }
 
   use Protocol
 
@@ -402,7 +402,11 @@ defmodule ElixirLS.LanguageServer.Server do
     %{
       "textDocumentSync" => 1,
       "hoverProvider" => true,
-      "completionProvider" => %{},
+      # Required to make autocomplete work in other editors
+      "completionProvider" => %{
+        resolveProvider: true,
+        triggerCharacters: ["."]
+      },
       "definitionProvider" => true,
       "documentFormattingProvider" => Formatting.supported?(),
       "signatureHelpProvider" => %{"triggerCharacters" => ["("]}

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -404,7 +404,8 @@ defmodule ElixirLS.LanguageServer.Server do
       "hoverProvider" => true,
       # Required to make autocomplete work in other editors
       "completionProvider" => %{
-        resolveProvider: true,
+        # This activate `completionItem/resolve` send by the client
+        resolveProvider: false,
         triggerCharacters: ["."]
       },
       "definitionProvider" => true,

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -43,7 +43,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     )
 
     Server.receive_packet(server, did_open(uri, "elixir", 1, code))
-    Server.receive_packet(server, completion_req(1, uri, 2, 29))
+    Server.receive_packet(server, completion_req(1, uri, 2, 25))
 
     assert_receive response(1, %{
                      "isIncomplete" => true,
@@ -145,7 +145,8 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                      "activeSignature" => 0,
                      "signatures" => [
                        %{
-                         "documentation" => "@spec inspect(Inspect.t, keyword) :: String.t\nInspects the given argument according to the `Inspect` protocol.\nThe second argument is a keyword list with options to control\ninspection.",
+                         "documentation" =>
+                           "@spec inspect(Inspect.t, keyword) :: String.t\nInspects the given argument according to the `Inspect` protocol.\nThe second argument is a keyword list with options to control\ninspection.",
                          "label" => "inspect(term, opts \\\\ [])",
                          "parameters" => [%{"label" => "term"}, %{"label" => "opts \\\\ []"}]
                        }
@@ -165,8 +166,9 @@ defmodule ElixirLS.LanguageServer.ServerTest do
                        "uri" => ^error_file,
                        "diagnostics" => [
                          %{
-                           "message" => "** (CompileError) lib/has_error.ex:4: undefined function does_not_exist" <>
-                             _,
+                           "message" =>
+                             "** (CompileError) lib/has_error.ex:4: undefined function does_not_exist" <>
+                               _,
                            "range" => %{"end" => %{"line" => 3}, "start" => %{"line" => 3}},
                            "severity" => 1
                          }


### PR DESCRIPTION
Hey! I've been testing elixir-ls with Sublime Text 3 LSP, I didn't made it work at first time so I fork the project and did a few fixes to make it work on another editors, hope is well implemented ^^'

I've only tested on Sublime Text 3 in Windows OS, elixir 1.6.0-dev, Erlang 20.1

_I just found a little bug with the pipe operator that I didn't manage to solve, if you write a module or a function after `|>` the auto-complete don't work_

Greetings!