### PR TITLE
Add ['.'] as trigger for autocompletion server capabilities.

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -402,7 +402,7 @@ defmodule ElixirLS.LanguageServer.Server do
     %{
       "textDocumentSync" => 1,
       "hoverProvider" => true,
-      "completionProvider" => %{},
+      "completionProvider" => %{triggerCharacters" => ["."]},
       "definitionProvider" => true,
       "documentFormattingProvider" => Formatting.supported?(),
       "signatureHelpProvider" => %{"triggerCharacters" => ["("]}


### PR DESCRIPTION
Hi first of all amazing work on this project.
I've been working with VSCode for a while now and it fell short in some aspects when coding with Elixir, that was until I found your package for it.

But I felt that the completion should be firing when `.` was pressed, as we're used to with `vscode-elixir`, the go-to package when using Elixir + VSCode.

I hope everything is in order.


And thanks again for the amazing work! 👍 