### PR TITLE
attempt to fix on windows

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -418,7 +418,7 @@ defmodule ElixirLS.LanguageServer.Server do
 
   defp trigger_build(state) do
     if build_enabled?(state) and state.build_ref == nil do
-      {_pid, build_ref} = Build.build(self(), SourceFile.path_from_uri(state.project_dir))
+      {_pid, build_ref} = Build.build(self(), state.project_dir)
       %__MODULE__{state | build_ref: build_ref, needs_build?: false}
     else
       %__MODULE__{state | needs_build?: true}


### PR DESCRIPTION
Hi there, 

I dived in a bit to fix https://github.com/JakeBecker/elixir-ls/issues/34, which happened on two Windows systems I have (so I suspect it's general for Windows). This PR fixes it *for me* but I'm not sure that I understand your code well enough to be certain it's a good fix.

Anyway, Server's `state.project_dir`, a path that wasn't an URI, was sent to `SourceFile.path_from_uri`. This function fails on Windows because absolute Windows paths look a little like an URI scheme and it's all incorrectly parsed and handled. On my computer, `project_dir` didn't contain an URI at all, but just an ordinary path. If that holds cross-OS, then this is the right fix.

Otherwise maybe we need to detect whether the path is a real path or a URI. E.g. by detecting whether the parameter starts with `"file:/"` but i'm not sure which URI schemes it needs to support.

Please advise. And thanks for your awesome work :-)
  