### PR TITLE
Reference support

### DIFF
--- a/apps/language_server/lib/language_server/protocol.ex
+++ b/apps/language_server/lib/language_server/protocol.ex
@@ -64,6 +64,16 @@ defmodule ElixirLS.LanguageServer.Protocol do
     end
   end
 
+  defmacro references_req(id, uri, line, character, include_declaration) do
+    quote do
+      request(unquote(id), "textDocument/references", %{
+        "textDocument" => %{"uri" => unquote(uri)},
+        "position" => %{"line" => unquote(line), "character" => unquote(character)},
+        "context" => %{"includeDeclaration" => unquote(include_declaration)}
+      })
+    end
+  end
+
   defmacro initialize_req(id, root_uri, client_capabilities) do
     quote do
       request(unquote(id), "initialize", %{

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -15,7 +15,7 @@ defmodule ElixirLS.LanguageServer.Providers.References do
   end
 
   def supported? do
-    :erlang.function_exported(Mix.Tasks.Xref, :calls, 0)
+    Mix.Tasks.Xref.__info__(:functions) |> Enum.member?({:calls, 0})
   end
 
   defp xref_at_cursor(text, line, character) do

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -1,0 +1,56 @@
+defmodule ElixirLS.LanguageServer.Providers.References do
+  @moduledoc """
+  This module provides References support by using
+  the `Mix.Tasks.Xref` task to find all references to
+  any function found at the provided location.
+  """
+
+  alias ElixirLS.LanguageServer.SourceFile
+  alias ElixirSense.Core.Metadata
+
+  def references(text, line, character, _include_declaration) do
+    # support _include_declaration
+    subject = get_subject(text, line, character)
+    {module, scope, arity} = get_line_scope(text, line)
+
+    cond do
+      subject == scope -> xref(module, scope, arity) |> Enum.map(&build_location/1)
+      true -> []
+    end
+  end
+
+  @xref_pattern ~r/(?<path>.*):(?<line>\d+): (?<function>.*)/
+  defp xref(module, scope, arity) do
+    ExUnit.CaptureIO.capture_io(fn ->
+      Mix.Tasks.Xref.run(["callers", "#{module}.#{scope}/#{arity}"])
+    end)
+    |> String.trim()
+    |> String.split("\n")
+    |> Enum.map(fn line ->
+      %{"path" => caller_path, "line" => caller_line} = Regex.named_captures(@xref_pattern, line)
+      %{uri: SourceFile.path_to_uri(caller_path), line: String.to_integer(caller_line) - 1}
+    end)
+  end
+
+  defp build_location(caller) do
+    %{
+      "uri" => caller.uri,
+      "range" => %{
+        "start" => %{"line" => caller.line, "character" => 0},
+        "end" => %{"line" => caller.line, "character" => 0}
+      }
+    }
+  end
+
+  defp get_subject(text, line, character) do
+    ElixirSense.Core.Source.subject(text, line + 1, character + 1) |> String.to_atom()
+  end
+
+  defp get_line_scope(text, line) do
+    %{module: module, scope: {scope, arity}} =
+      ElixirSense.Core.Parser.parse_string(text, true, true, line + 1)
+      |> Metadata.get_env(line + 1)
+
+    {module, scope, arity}
+  end
+end

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -14,6 +14,10 @@ defmodule ElixirLS.LanguageServer.Providers.References do
     |> Enum.map(&build_location/1)
   end
 
+  def supported? do
+    :erlang.function_exported(Mix.Tasks.Xref, :calls, 0)
+  end
+
   defp xref_at_cursor(text, line, character) do
     env_at_cursor = line_environment(text, line)
 

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -36,7 +36,7 @@ defmodule ElixirLS.LanguageServer.Providers.References do
     Source.subject(text, line + 1, character + 1)
   end
 
-  defp expand_mod_fun(nil, _environment), do: nil
+  defp expand_mod_fun({nil, nil}, _environment), do: nil
 
   defp expand_mod_fun(mod_fun, %{imports: imports, aliases: aliases, module: module}) do
     case Introspection.actual_mod_fun(mod_fun, imports, aliases, module) do

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -403,7 +403,7 @@ defmodule ElixirLS.LanguageServer.Server do
       "hoverProvider" => true,
       "completionProvider" => %{"triggerCharacters" => ["."]},
       "definitionProvider" => true,
-      "referencesProvider" => true,
+      "referencesProvider" => References.supported?(),
       "documentFormattingProvider" => Formatting.supported?(),
       "signatureHelpProvider" => %{"triggerCharacters" => ["("]}
     }

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -23,6 +23,7 @@ defmodule ElixirLS.LanguageServer.Server do
     Completion,
     Hover,
     Definition,
+    References,
     Formatting,
     SignatureHelp
   }
@@ -322,6 +323,17 @@ defmodule ElixirLS.LanguageServer.Server do
     {:async, fun, state}
   end
 
+  defp handle_request(references_req(_id, uri, line, character, include_declaration), state) do
+    fun = fn ->
+      {
+        :ok,
+        References.references(state.source_files[uri].text, line, character, include_declaration)
+      }
+    end
+
+    {:async, fun, state}
+  end
+
   defp handle_request(hover_req(_id, uri, line, character), state) do
     fun = fn ->
       Hover.hover(state.source_files[uri].text, line, character)
@@ -391,6 +403,7 @@ defmodule ElixirLS.LanguageServer.Server do
       "hoverProvider" => true,
       "completionProvider" => %{"triggerCharacters" => ["."]},
       "definitionProvider" => true,
+      "referencesProvider" => true,
       "documentFormattingProvider" => Formatting.supported?(),
       "signatureHelpProvider" => %{"triggerCharacters" => ["("]}
     }


### PR DESCRIPTION
Hey @JakeBecker, love ElixirLS and the VSCode plugin. I wanted to take a crack at reference support (https://github.com/JakeBecker/elixir-ls/issues/19).

This seems to handle modules and functions pretty well, but there's no support for variables since I'm just leveraging `Mix.Tasks.Xref`.

Here's a little GIF:

![refs](https://user-images.githubusercontent.com/55462/36627811-73393bae-18fd-11e8-8045-944d958636db.gif)

Figured I'd get it front of you to see if the direction works for you. Happy to add tests and refactor if this seems like it could actually be useful.

CC @balduncle as an interested party