### PR TITLE
Add documentSymbol provider

### DIFF
--- a/apps/language_server/lib/language_server/protocol.ex
+++ b/apps/language_server/lib/language_server/protocol.ex
@@ -109,6 +109,14 @@ defmodule ElixirLS.LanguageServer.Protocol do
     end
   end
 
+  defmacro document_symbol_req(id, uri) do
+    quote do
+      request(unquote(id), "textDocument/documentSymbol", %{
+        "textDocument" => %{"uri" => unquote(uri)}
+      })
+    end
+  end
+
   defmacro signature_help_req(id, uri, line, character) do
     quote do
       request(unquote(id), "textDocument/signatureHelp", %{

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -48,7 +48,14 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
 
   # Identify and extract the module symbol, and the symbols contained within the module
   defp extract_module({:defmodule, _, _child_ast} = ast) do
-    {_, _, [{:__aliases__, location, module_name}, [do: {:__block__, [], mod_defns}]]} = ast
+    {_, _, [{:__aliases__, location, module_name}, [do: module_body]]} = ast
+
+    mod_defns =
+      case module_body do
+        {:__block__, [], mod_defns} -> mod_defns
+        stmt -> [stmt]
+      end
+
     module_name = Enum.join(module_name, ".")
 
     module_symbols =

--- a/apps/language_server/lib/language_server/providers/document_symbols.ex
+++ b/apps/language_server/lib/language_server/providers/document_symbols.ex
@@ -1,0 +1,134 @@
+defmodule ElixirLS.LanguageServer.Providers.DocumentSymbols do
+  @moduledoc """
+  Document Symbols provider
+  """
+  @symbol_enum %{
+    file: 1,
+    module: 2,
+    namespace: 3,
+    package: 4,
+    class: 5,
+    method: 6,
+    property: 7,
+    field: 8,
+    constructor: 9,
+    enum: 10,
+    interface: 11,
+    function: 12,
+    variable: 13,
+    constant: 14,
+    string: 15,
+    number: 16,
+    boolean: 17,
+    array: 18,
+    object: 19,
+    key: 20,
+    null: 21,
+    enum_member: 22,
+    struct: 23,
+    event: 24,
+    operator: 25,
+    type_parameter: 26
+  }
+
+  def symbols(uri, text) do
+    symbols = list_symbols(text) |> Enum.map(&build_symbol_information(uri, &1))
+    {:ok, symbols}
+  end
+
+  defp list_symbols(src) do
+    {_ast, symbol_list} =
+      Code.string_to_quoted!(src, columns: true, line: 0)
+      |> Macro.prewalk([], fn ast, symbols ->
+        {ast, extract_module(ast) ++ symbols}
+      end)
+
+    symbol_list
+  end
+
+  # Identify and extract the module symbol, and the symbols contained within the module
+  defp extract_module({:defmodule, _, _child_ast} = ast) do
+    {_, _, [{:__aliases__, location, module_name}, [do: {:__block__, [], mod_defns}]]} = ast
+    module_name = Enum.join(module_name, ".")
+
+    module_symbols =
+      mod_defns
+      |> Enum.map(&extract_symbol(module_name, &1))
+      |> Enum.reject(&is_nil/1)
+
+    [%{type: :module, name: module_name, location: location, container: nil}] ++ module_symbols
+  end
+
+  defp extract_module(_ast), do: []
+
+  # Module Variable
+  defp extract_symbol(_, {:@, _, [{:moduledoc, _, _}]}), do: nil
+  defp extract_symbol(_, {:@, _, [{:doc, _, _}]}), do: nil
+  defp extract_symbol(_, {:@, _, [{:spec, _, _}]}), do: nil
+  defp extract_symbol(_, {:@, _, [{:behaviour, _, _}]}), do: nil
+  defp extract_symbol(_, {:@, _, [{:impl, _, _}]}), do: nil
+  defp extract_symbol(_, {:@, _, [{:type, _, _}]}), do: nil
+  defp extract_symbol(_, {:@, _, [{:typedoc, _, _}]}), do: nil
+  defp extract_symbol(_, {:@, _, [{:enforce_keys, _, _}]}), do: nil
+
+  defp extract_symbol(current_module, {:@, _, [{name, location, _}]}) do
+    %{type: :constant, name: "@#{name}", location: location, container: current_module}
+  end
+
+  # Function
+  defp extract_symbol(current_module, {:def, _, [{_, location, _} = fn_head | _]}) do
+    %{
+      type: :function,
+      name: Macro.to_string(fn_head),
+      location: location,
+      container: current_module
+    }
+  end
+
+  # Private Function
+  defp extract_symbol(current_module, {:defp, _, [{_, location, _} = fn_head | _]}) do
+    %{
+      type: :function,
+      name: Macro.to_string(fn_head),
+      location: location,
+      container: current_module
+    }
+  end
+
+  # Macro
+  defp extract_symbol(current_module, {:defmacro, _, [{_, location, _} = fn_head | _]}) do
+    %{
+      type: :function,
+      name: Macro.to_string(fn_head),
+      location: location,
+      container: current_module
+    }
+  end
+
+  # Test
+  defp extract_symbol(current_module, {:test, location, [name | _]}) do
+    %{
+      type: :function,
+      name: ~s(test "#{name}"),
+      location: location,
+      container: current_module
+    }
+  end
+
+  defp extract_symbol(_, _), do: nil
+
+  defp build_symbol_information(uri, info) do
+    %{
+      name: info.name,
+      kind: @symbol_enum[info.type],
+      containerName: info.container,
+      location: %{
+        uri: uri,
+        range: %{
+          start: %{line: info.location[:line], character: info.location[:column] - 1},
+          end: %{line: info.location[:line], character: info.location[:column] - 1}
+        }
+      }
+    }
+  end
+end

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -24,7 +24,8 @@ defmodule ElixirLS.LanguageServer.Server do
     Hover,
     Definition,
     Formatting,
-    SignatureHelp
+    SignatureHelp,
+    DocumentSymbols
   }
 
   use Protocol
@@ -330,6 +331,14 @@ defmodule ElixirLS.LanguageServer.Server do
     {:async, fun, state}
   end
 
+  defp handle_request(document_symbol_req(_id, uri), state) do
+    fun = fn ->
+      DocumentSymbols.symbols(uri, state.source_files[uri].text)
+    end
+
+    {:async, fun, state}
+  end
+
   defp handle_request(completion_req(_id, uri, line, character), state) do
     snippets_supported =
       !!get_in(state.client_capabilities, [
@@ -392,7 +401,8 @@ defmodule ElixirLS.LanguageServer.Server do
       "completionProvider" => %{"triggerCharacters" => ["."]},
       "definitionProvider" => true,
       "documentFormattingProvider" => Formatting.supported?(),
-      "signatureHelpProvider" => %{"triggerCharacters" => ["("]}
+      "signatureHelpProvider" => %{"triggerCharacters" => ["("]},
+      "documentSymbolProvider" => true
     }
   end
 

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -1,0 +1,132 @@
+defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
+  alias ElixirLS.LanguageServer.Providers.DocumentSymbols
+  use ExUnit.Case
+
+  test "returns symbol information" do
+    uri = "file://project/file.ex"
+    text = ~S[
+      defmodule MyModule do
+        @my_mod_var "module variable"
+        def my_fn(arg), do: :ok
+        defp my_private_fn(arg), do: :ok
+        defmacro my_macro(), do: :ok
+        defmacrop my_private_macro(), do: :ok
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                containerName: nil,
+                kind: 2,
+                location: %{
+                  range: %{
+                    end: %{character: 16, line: 1},
+                    start: %{character: 16, line: 1}
+                  },
+                  uri: ^uri
+                },
+                name: "MyModule"
+              },
+              %{
+                containerName: "MyModule",
+                kind: 14,
+                location: %{
+                  range: %{
+                    end: %{character: 9, line: 2},
+                    start: %{character: 9, line: 2}
+                  },
+                  uri: ^uri
+                },
+                name: "@my_mod_var"
+              },
+              %{
+                containerName: "MyModule",
+                kind: 12,
+                location: %{
+                  range: %{
+                    end: %{character: 12, line: 3},
+                    start: %{character: 12, line: 3}
+                  },
+                  uri: ^uri
+                },
+                name: "my_fn(arg)"
+              },
+              %{
+                containerName: "MyModule",
+                kind: 12,
+                location: %{
+                  range: %{
+                    end: %{character: 13, line: 4},
+                    start: %{character: 13, line: 4}
+                  },
+                  uri: ^uri
+                },
+                name: "my_private_fn(arg)"
+              },
+              %{
+                containerName: "MyModule",
+                kind: 12,
+                location: %{
+                  range: %{
+                    end: %{character: 17, line: 5},
+                    start: %{character: 17, line: 5}
+                  },
+                  uri: ^uri
+                },
+                name: "my_macro()"
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+
+  test "handles nested module definitions" do
+    uri = "file://project/file.ex"
+    text = ~S[
+      defmodule MyModule do
+        defmodule SubModule do
+          def my_fn(), do: :ok
+        end
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                containerName: nil,
+                kind: 2,
+                location: %{
+                  range: %{
+                    end: %{character: 18, line: 2},
+                    start: %{character: 18, line: 2}
+                  },
+                  uri: "file://project/file.ex"
+                },
+                name: "SubModule"
+              },
+              %{
+                containerName: "SubModule",
+                kind: 12,
+                location: %{
+                  range: %{
+                    end: %{character: 14, line: 3},
+                    start: %{character: 14, line: 3}
+                  },
+                  uri: ^uri
+                },
+                name: "my_fn()"
+              },
+              %{
+                containerName: nil,
+                kind: 2,
+                location: %{
+                  range: %{
+                    end: %{character: 16, line: 1},
+                    start: %{character: 16, line: 1}
+                  },
+                  uri: ^uri
+                },
+                name: "MyModule"
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
+end

--- a/apps/language_server/test/providers/document_symbols_test.exs
+++ b/apps/language_server/test/providers/document_symbols_test.exs
@@ -129,4 +129,42 @@ defmodule ElixirLS.LanguageServer.Providers.DocumentSymbolsTest do
               }
             ]} = DocumentSymbols.symbols(uri, text)
   end
+
+  test "handles exunit tests" do
+    uri = "file://project/test.exs"
+    text = ~S[
+      defmodule MyModuleTest do
+        use ExUnit.Case
+        test "does something", do: :ok
+      end
+    ]
+
+    assert {:ok,
+            [
+              %{
+                containerName: nil,
+                kind: 2,
+                location: %{
+                  range: %{
+                    end: %{character: 16, line: 1},
+                    start: %{character: 16, line: 1}
+                  },
+                  uri: ^uri
+                },
+                name: "MyModuleTest"
+              },
+              %{
+                containerName: "MyModuleTest",
+                kind: 12,
+                location: %{
+                  range: %{
+                    end: %{character: 8, line: 3},
+                    start: %{character: 8, line: 3}
+                  },
+                  uri: ^uri
+                },
+                name: "test \"does something\""
+              }
+            ]} = DocumentSymbols.symbols(uri, text)
+  end
 end


### PR DESCRIPTION
Here's a shot at supporting `textDocument/documentSymbol` requests (#21).

It's nothing terribly complicated — it just walks the AST and picks out functions, macros, modules, module variables and (as a special case) tests. I'm using the module as the `container` property in the response which seemed reasonable, and looks nice in the UI.

Since we can have multiple function definitions in Elixir I've set the `name` property to the function name + its arguments to disambiguate. 

A GIF:
![symbols](https://user-images.githubusercontent.com/55462/36636919-c89856de-1984-11e8-8c93-852d7cbdf240.gif)
