### PR TITLE
Hack: Override MIX_EXS in launcher scripts so that Mix won't load mix…

### DIFF
--- a/apps/debugger/lib/mix.tasks.elixir_ls.debugger.ex
+++ b/apps/debugger/lib/mix.tasks.elixir_ls.debugger.ex
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.ElixirLs.Debugger do
 
   def run(_args) do
     WireProtocol.intercept_output(&Output.print/1, &Output.print_err/1)
+    ElixirLS.Utils.Launch.restore_mix_exs_var()
     Application.ensure_all_started(:debugger, :permanent)
     IO.puts("Started ElixirLS debugger")
     WireProtocol.stream_packets(&Server.receive_packet/1)

--- a/apps/elixir_ls_utils/lib/launch.ex
+++ b/apps/elixir_ls_utils/lib/launch.ex
@@ -1,0 +1,19 @@
+defmodule ElixirLS.Utils.Launch do
+  @doc """
+  This is an unfortunate hack to allow us to launch the language server or debugger using Mix
+  without automatically loading the mixfile in the current directory (which is unsafe until we've
+  called [ElixirLS.Utils.WireProtocol.intercept_output/2])
+
+  The launcher script overrides MIX_EXS, but we can restore it from ELIXIR_LS_MIX_EXS once
+  we've launched.
+  """
+  def restore_mix_exs_var do
+    case System.get_env("ELIXIR_LS_MIX_EXS") do
+      nil -> System.delete_env("MIX_EXS")
+      "" -> System.delete_env("MIX_EXS")
+      mix_exs -> System.put_env("MIX_EXS", mix_exs)
+    end
+
+    System.delete_env("ELIXIR_LS_MIX_EXS")
+  end
+end

--- a/apps/elixir_ls_utils/priv/debugger.bat
+++ b/apps/elixir_ls_utils/priv/debugger.bat
@@ -1,4 +1,10 @@
 @echo off & setlocal enabledelayedexpansion
 
 SET ERL_LIBS=%~dp0
+
+REM HACK: We don't want Mix to load the mixfile in the cwd, so we override MIX_EXS here. We can
+REM restore it from ELIXIR_LS_MIX_EXS once we've launched.
+SET ELIXIR_LS_MIX_EXS=%MIX_EXS%
+SET MIX_EXS="."
+
 mix elixir_ls.debugger

--- a/apps/elixir_ls_utils/priv/debugger.sh
+++ b/apps/elixir_ls_utils/priv/debugger.sh
@@ -11,6 +11,11 @@ readlink_f () {
   fi
 }
 
+# HACK: We don't want Mix to load the mixfile in the cwd, so we override MIX_EXS here. We can
+# restore it from ELIXIR_LS_MIX_EXS once we've launched.
+export ELIXIR_LS_MIX_EXS=$MIX_EXS
+export MIX_EXS="."
+
 SCRIPT=$(readlink_f $0)
 SCRIPTPATH=`dirname $SCRIPT`
 export ERL_LIBS="$SCRIPTPATH:$ERL_LIBS"

--- a/apps/elixir_ls_utils/priv/language_server.bat
+++ b/apps/elixir_ls_utils/priv/language_server.bat
@@ -1,4 +1,10 @@
 @echo off & setlocal enabledelayedexpansion
 
 SET ERL_LIBS=%~dp0
+
+REM HACK: We don't want Mix to load the mixfile in the cwd, so we override MIX_EXS here. We can
+REM restore it from ELIXIR_LS_MIX_EXS once we've launched.
+SET ELIXIR_LS_MIX_EXS=%MIX_EXS%
+SET MIX_EXS="."
+
 mix elixir_ls.language_server

--- a/apps/elixir_ls_utils/priv/language_server.sh
+++ b/apps/elixir_ls_utils/priv/language_server.sh
@@ -11,7 +11,13 @@ readlink_f () {
   fi
 }
 
+# HACK: We don't want Mix to load the mixfile in the cwd, so we override MIX_EXS here. We can
+# restore it from ELIXIR_LS_MIX_EXS once we've launched.
+export ELIXIR_LS_MIX_EXS=$MIX_EXS
+export MIX_EXS="."
+
 SCRIPT=$(readlink_f $0)
 SCRIPTPATH=`dirname $SCRIPT`
 export ERL_LIBS="$SCRIPTPATH:$ERL_LIBS"
+
 mix elixir_ls.language_server

--- a/apps/language_server/lib/mix.tasks.elixir_ls.language_server.ex
+++ b/apps/language_server/lib/mix.tasks.elixir_ls.language_server.ex
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.ElixirLs.LanguageServer do
 
   def run(_args) do
     WireProtocol.intercept_output(&JsonRpc.print/1, &JsonRpc.print_err/1)
+    ElixirLS.Utils.Launch.restore_mix_exs_var()
     configure_logger()
     Application.ensure_all_started(:language_server, :permanent)
     Mix.shell(ElixirLS.LanguageServer.MixShell)


### PR DESCRIPTION
…file in cwd on launch

Mix will automatically load the mixfile at the current directory which is unsafe because it may print to stdout before we've begun intercepting output. The launch scripts now change the environment variable `MIX_EXS` so that won't happen, and then we restore it from `ELIXIR_LS_MIX_EXS` on the slim chance the user actually has set `MIX_EXS` to something.

Fixes #51 