### PR TITLE
Support Find References in umbrella apps

### DIFF
--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -8,21 +8,23 @@ defmodule ElixirLS.LanguageServer.Build do
       {nil, nil}
     else
       spawn_monitor(fn ->
-        {us, _} =
-          :timer.tc(fn ->
-            IO.puts("Compiling with Mix env #{Mix.env()}")
+        with_build_lock(__MODULE__, fn ->
+          {us, _} =
+            :timer.tc(fn ->
+              IO.puts("Compiling with Mix env #{Mix.env()}")
 
-            case reload_project() do
-              {:ok, mixfile_diagnostics} ->
-                {status, diagnostics} = compile()
-                Server.build_finished(parent, {status, mixfile_diagnostics ++ diagnostics})
+              case reload_project() do
+                {:ok, mixfile_diagnostics} ->
+                  {status, diagnostics} = compile()
+                  Server.build_finished(parent, {status, mixfile_diagnostics ++ diagnostics})
 
-              {:error, mixfile_diagnostics} ->
-                Server.build_finished(parent, {:error, mixfile_diagnostics})
-            end
-          end)
+                {:error, mixfile_diagnostics} ->
+                  Server.build_finished(parent, {:error, mixfile_diagnostics})
+              end
+            end)
 
-        JsonRpc.log_message(:info, "Compile took #{div(us, 1000)} milliseconds")
+          JsonRpc.log_message(:info, "Compile took #{div(us, 1000)} milliseconds")
+        end)
       end)
     end
   end
@@ -91,6 +93,22 @@ defmodule ElixirLS.LanguageServer.Build do
       severity: :error,
       details: error
     }
+  end
+
+  def with_build_lock(requester, func) do
+    IO.puts("#{requester} requesting lock.")
+
+    :global.trans({:compilation_lock, requester}, fn ->
+      IO.puts("#{requester} acquired lock.")
+
+      {us, result} =
+        :timer.tc(fn ->
+          func.()
+        end)
+
+      IO.puts("#{requester} releasing lock after #{div(us, 1000)}ms.")
+      result
+    end)
   end
 
   defp reload_project do

--- a/apps/language_server/lib/language_server/build.ex
+++ b/apps/language_server/lib/language_server/build.ex
@@ -8,7 +8,7 @@ defmodule ElixirLS.LanguageServer.Build do
       {nil, nil}
     else
       spawn_monitor(fn ->
-        with_build_lock(__MODULE__, fn ->
+        with_build_lock(fn ->
           {us, _} =
             :timer.tc(fn ->
               IO.puts("Compiling with Mix env #{Mix.env()}")
@@ -95,20 +95,8 @@ defmodule ElixirLS.LanguageServer.Build do
     }
   end
 
-  def with_build_lock(requester, func) do
-    IO.puts("#{requester} requesting lock.")
-
-    :global.trans({:compilation_lock, requester}, fn ->
-      IO.puts("#{requester} acquired lock.")
-
-      {us, result} =
-        :timer.tc(fn ->
-          func.()
-        end)
-
-      IO.puts("#{requester} releasing lock after #{div(us, 1000)}ms.")
-      result
-    end)
+  def with_build_lock(func) do
+    :global.trans({__MODULE__, self()}, func)
   end
 
   defp reload_project do

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -50,8 +50,6 @@ defmodule ElixirLS.LanguageServer.Providers.References do
   defp add_arity({mod, fun}, %{scope: {fun, arity}, module: mod}), do: {mod, fun, arity}
   defp add_arity({mod, fun}, _env), do: {mod, fun, nil}
 
-  defp callers(nil), do: []
-
   defp callers(mfa) do
     if Mix.Project.umbrella?() do
       umbrella_calls()

--- a/apps/language_server/lib/language_server/providers/references.ex
+++ b/apps/language_server/lib/language_server/providers/references.ex
@@ -9,7 +9,7 @@ defmodule ElixirLS.LanguageServer.Providers.References do
   alias ElixirSense.Core.{Metadata, Parser, Source, Introspection}
 
   def references(text, line, character, _include_declaration) do
-    Build.with_build_lock(__MODULE__, fn ->
+    Build.with_build_lock(fn ->
       xref_at_cursor(text, line, character)
       |> Enum.filter(fn %{line: line} -> is_integer(line) end)
       |> Enum.map(&build_location/1)

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -327,7 +327,13 @@ defmodule ElixirLS.LanguageServer.Server do
     fun = fn ->
       {
         :ok,
-        References.references(state.source_files[uri].text, line, character, include_declaration)
+        References.references(
+          state.source_files[uri].text,
+          line,
+          character,
+          state.project_dir,
+          include_declaration
+        )
       }
     end
 

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -325,16 +325,13 @@ defmodule ElixirLS.LanguageServer.Server do
 
   defp handle_request(references_req(_id, uri, line, character, include_declaration), state) do
     fun = fn ->
-      {
-        :ok,
-        References.references(
-          state.source_files[uri].text,
-          line,
-          character,
-          state.project_dir,
-          include_declaration
-        )
-      }
+      {:ok,
+       References.references(
+         state.source_files[uri].text,
+         line,
+         character,
+         include_declaration
+       )}
     end
 
     {:async, fun, state}

--- a/apps/language_server/test/fixtures/references/lib/a.ex
+++ b/apps/language_server/test/fixtures/references/lib/a.ex
@@ -1,0 +1,5 @@
+defmodule A do
+  def fun do
+    B.fun()
+  end
+end

--- a/apps/language_server/test/fixtures/references/lib/b.ex
+++ b/apps/language_server/test/fixtures/references/lib/b.ex
@@ -1,0 +1,5 @@
+defmodule B do
+  def fun do
+    :ok
+  end
+end

--- a/apps/language_server/test/fixtures/references/mix.exs
+++ b/apps/language_server/test/fixtures/references/mix.exs
@@ -1,0 +1,11 @@
+defmodule References.MixProject do
+  use Mix.Project
+
+  def project do
+    [app: :references, version: "0.1.0"]
+  end
+
+  def application do
+    []
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella/apps/app1/lib/app1.ex
+++ b/apps/language_server/test/fixtures/umbrella/apps/app1/lib/app1.ex
@@ -1,0 +1,5 @@
+defmodule App1 do
+  def hello() do
+    App2.hello()
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella/apps/app1/mix.exs
+++ b/apps/language_server/test/fixtures/umbrella/apps/app1/mix.exs
@@ -1,0 +1,15 @@
+defmodule App1.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :app1, version: "0.1.0", deps: deps()]
+  end
+
+  def application do
+    []
+  end
+
+  defp deps do
+    [{:app2, in_umbrella: true}]
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella/apps/app2/lib/app2.ex
+++ b/apps/language_server/test/fixtures/umbrella/apps/app2/lib/app2.ex
@@ -1,0 +1,5 @@
+defmodule App2 do
+  def hello do
+    :app2
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella/apps/app2/mix.exs
+++ b/apps/language_server/test/fixtures/umbrella/apps/app2/mix.exs
@@ -1,0 +1,11 @@
+defmodule App2.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :app2, version: "0.1.0"]
+  end
+
+  def application do
+    []
+  end
+end

--- a/apps/language_server/test/fixtures/umbrella/mix.exs
+++ b/apps/language_server/test/fixtures/umbrella/mix.exs
@@ -1,0 +1,7 @@
+defmodule Umbrella.Mixfile do
+  use Mix.Project
+
+  def project do
+    [apps_path: "apps"]
+  end
+end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -212,6 +212,33 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     end)
   end
 
+  test "finds references in non-umbrella project", %{server: server} do
+    in_fixture(__DIR__, "references", fn ->
+      file_path = "lib/b.ex"
+      file_uri = SourceFile.path_to_uri(file_path)
+      text = File.read!(file_path)
+      reference_uri = SourceFile.path_to_uri("lib/a.ex")
+
+      initialize(server)
+      Server.receive_packet(server, did_open(file_uri, "elixir", 1, text))
+
+      Server.receive_packet(
+        server,
+        references_req(4, file_uri, 1, 8, true)
+      )
+
+      assert_receive(
+        response(4, [
+          %{
+            "range" => %{"start" => %{"line" => 2}, "end" => %{"line" => 2}},
+            "uri" => ^reference_uri
+          }
+        ]),
+        5000
+      )
+    end)
+  end
+
   test "finds references in umbrella project", %{server: server} do
     in_fixture(__DIR__, "umbrella", fn ->
       file_path = "apps/app2/lib/app2.ex"

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -6,6 +6,20 @@ defmodule ElixirLS.LanguageServer.ServerTest do
 
   doctest(Server)
 
+  defp initialize(server) do
+    Server.receive_packet(server, initialize_req(1, root_uri(), %{}))
+    Server.receive_packet(server, notification("initialized"))
+
+    Server.receive_packet(
+      server,
+      did_change_configuration(%{"elixirLS" => %{"dialyzerEnabled" => false}})
+    )
+  end
+
+  defp root_uri do
+    SourceFile.path_to_uri(File.cwd!())
+  end
+
   setup do
     {:ok, server} = Server.start_link()
     {:ok, packet_capture} = PacketCapture.start_link(self())
@@ -105,16 +119,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
 
   test "formatter", %{server: server} do
     in_fixture(__DIR__, "formatter", fn ->
-      root_uri = SourceFile.path_to_uri(File.cwd!())
-      Server.receive_packet(server, initialize_req(1, root_uri, %{}))
-      Server.receive_packet(server, notification("initialized"))
-
-      Server.receive_packet(
-        server,
-        did_change_configuration(%{"elixirLS" => %{"dialyzerEnabled" => false}})
-      )
-
-      uri = Path.join([root_uri, "file.ex"])
+      uri = Path.join([root_uri(), "file.ex"])
       code = ~S(
       defmodule MyModule do
       def my_fn do
@@ -123,6 +128,7 @@ defmodule ElixirLS.LanguageServer.ServerTest do
       end
       )
 
+      initialize(server)
       Server.receive_packet(server, did_open(uri, "elixir", 1, code))
       Server.receive_packet(server, formatting_req(1, uri, %{}))
 
@@ -168,16 +174,9 @@ defmodule ElixirLS.LanguageServer.ServerTest do
 
   test "reports build diagnostics", %{server: server} do
     in_fixture(__DIR__, "build_errors", fn ->
-      root_uri = SourceFile.path_to_uri(File.cwd!())
       error_file = SourceFile.path_to_uri("lib/has_error.ex")
 
-      Server.receive_packet(server, initialize_req(1, root_uri, %{}))
-      Server.receive_packet(server, notification("initialized"))
-
-      Server.receive_packet(
-        server,
-        did_change_configuration(%{"elixirLS" => %{"dialyzerEnabled" => false}})
-      )
+      initialize(server)
 
       assert_receive notification("textDocument/publishDiagnostics", %{
                        "uri" => ^error_file,
@@ -196,15 +195,9 @@ defmodule ElixirLS.LanguageServer.ServerTest do
 
   test "reports error if no mixfile", %{server: server} do
     in_fixture(__DIR__, "no_mixfile", fn ->
-      root_uri = SourceFile.path_to_uri(File.cwd!())
       mixfile_uri = SourceFile.path_to_uri("mix.exs")
-      Server.receive_packet(server, initialize_req(1, root_uri, %{}))
-      Server.receive_packet(server, notification("initialized"))
 
-      Server.receive_packet(
-        server,
-        did_change_configuration(%{"elixirLS" => %{"dialyzerEnabled" => false}})
-      )
+      initialize(server)
 
       assert_receive notification("textDocument/publishDiagnostics", %{
                        "uri" => ^mixfile_uri,


### PR DESCRIPTION
Here's an attempt at addressing #55. Little heavy on the logging _but_ I could see it being nice if any problems occur. 

I ran this on a decently sized umbrella app with a compile time of 22 seconds. I confirmed that while "Find References" was waiting to acquire the lock, VSCode conveniently displays...

<img width="487" alt="screen shot 2018-03-01 at 11 12 52 pm" src="https://user-images.githubusercontent.com/55462/36887586-b6481aac-1da6-11e8-96c8-0c761fc59fb9.png">

Thoughts @JakeBecker? 