### PR TITLE
Do not add a space after Kernel.SpecialForms like __MODULE__

### DIFF
--- a/apps/language_server/lib/language_server/providers/completion.ex
+++ b/apps/language_server/lib/language_server/providers/completion.ex
@@ -429,7 +429,7 @@ defmodule ElixirLS.LanguageServer.Providers.Completion do
           {text, text}
 
         use_name_only?(origin, name) ->
-          {name, name <> " "}
+          {name, name}
 
         true ->
           label = function_label(name, args, arity)


### PR DESCRIPTION
Hi there 👋 

### Issue

When using one of the Kernel.SpecialForms like `__MODULE__`, I rarely want a space to be automatically added after it.

A few examples where this is particularly annoying are:

- `GenServer.call(__MODULE__, message)` with no space between the `__MODULE__` and the `,`
- `__MODULE__.my_other_function()` with no space between the `__MODULE__` and the `.`
- `Macro.expand_once(ast, __ENV__)` with no space between `__MODULE__` and the `)`

### Changes

In order to address this, this PR simply removes the space added by the `use_name_only?/2` function.

What do you think?

Best 🤗