### PR TITLE
Disable custom logger backend on Elixir 1.7.0-dev due to incompatibility

### DIFF
--- a/apps/language_server/lib/language_server/cli.ex
+++ b/apps/language_server/lib/language_server/cli.ex
@@ -6,7 +6,11 @@ defmodule ElixirLS.LanguageServer.CLI do
     WireProtocol.intercept_output(&JsonRpc.print/1, &JsonRpc.print_err/1)
     Launch.start_mix()
 
-    configure_logger()
+    # TODO: Figure out a safe way to use the custom logger backend in Elixir 1.7
+    unless Version.match?(System.version(), ">= 1.7.0-dev") do
+      configure_logger()
+    end
+
     Application.ensure_all_started(:language_server, :permanent)
     IO.puts("Started ElixirLS")
 


### PR DESCRIPTION
Fixes #87 