### PR TITLE
Path file path instead of contents to :dialyzer_utils.get_core_from_b…

### DIFF
--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -211,7 +211,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     changed_contents =
       Task.async_stream(changed, fn file ->
         content = File.read!(file)
-        {file, content, module_md5(content)}
+        {file, content, module_md5(file)}
       end)
 
     file_changes =
@@ -357,8 +357,8 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     File.exists?(path) and String.starts_with?(Path.absname(path), File.cwd!())
   end
 
-  defp module_md5(content) do
-    case :dialyzer_utils.get_core_from_beam(content) do
+  defp module_md5(file) do
+    case :dialyzer_utils.get_core_from_beam(to_charlist(file)) do
       {:ok, core} ->
         core_bin = :erlang.term_to_binary(core)
         :crypto.hash(:md5, core_bin)


### PR DESCRIPTION
…eam/1

Under the hood, this function can take either a charlist with the file path or the file's contents as a binary. However, if it fails (due to no debug_info chunk, for example), it will crash when the argument is the file's contents instead of path. Unfortunately, changing this means we do extraneous file reads from disk, but it's worth it for reliability.

Fixes #92 