### PR TITLE
New feature: Suggest specs based on Dialyzer's success typings using code lenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Elixir Language Server provides a server that runs in the background, provid
 
 - Debugger support (requires Erlang >= OTP 19)
 - Automatic, incremental Dialyzer analysis (requires Erlang OTP 20)
+- Automatic inline suggestion of @specs based on Dialyzer's inferred success typings
 - Inline reporting of build warnings and errors (requires Elixir >= 1.6)
 - Documentation lookup on hover
 - Go-to-definition
@@ -19,10 +20,12 @@ The Elixir Language Server provides a server that runs in the background, provid
 ## Supported versions
 
 Elixir:
+
 - 1.6.0 minimum
 - \>= 1.6.6 recommended
 
 Erlang:
+
 - OTP 18 minimum
 - \>= OTP 20 recommended
 
@@ -31,7 +34,7 @@ You may want to install Elixir and Erlang from source, using the [kiex](https://
 ## IDE plugins
 
 | IDE      | Plugin                                                                        | Support                                 |
-|----------|-------------------------------------------------------------------------------|-----------------------------------------|
+| -------- | ----------------------------------------------------------------------------- | --------------------------------------- |
 | VS Code  | [JakeBecker/vscode-elixir-ls](https://github.com/JakeBecker/vscode-elixir-ls) | Supports all ElixirLS features          |
 | Atom IDE | [JakeBecker/ide-elixir](https://github.com/JakeBecker/ide-elixir)             | Does not support debugger or output log |
 
@@ -73,7 +76,6 @@ If you're using Erlang >= OTP 20, ElixirLS will automatically analyze your proje
 You can control which warnings are shown using the `elixirLS.dialyzerWarnOpts` setting in your project or IDE's `settings.json`. To disable it completely, set `elixirLS.dialyzerEnabled` to false.
 
 ElixirLS's Dialyzer integration uses internal, undocumented Dialyzer APIs, and so it won't be robust against changes to these APIs in future Erlang versions.
-
 
 ## Building and running
 

--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -1,6 +1,6 @@
 defmodule ElixirLS.LanguageServer.Dialyzer do
   alias ElixirLS.LanguageServer.{JsonRpc, Server}
-  alias ElixirLS.LanguageServer.Dialyzer.{Manifest, Analyzer, Utils}
+  alias ElixirLS.LanguageServer.Dialyzer.{Manifest, Analyzer, Utils, SuccessTypings}
   import Utils
   require Logger
   use GenServer
@@ -12,13 +12,14 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     :root_path,
     :analysis_pid,
     :write_manifest_pid,
-    needs_analysis?: false,
+    :build_ref,
     warn_opts: [],
     mod_deps: %{},
     warnings: %{},
     file_changes: %{},
     removed_files: [],
-    md5: %{}
+    md5: %{},
+    specs_cache: %{}
   ]
 
   # Client API
@@ -45,11 +46,11 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     GenServer.start_link(__MODULE__, {parent, root_path}, name: {:global, {parent, __MODULE__}})
   end
 
-  def analyze(parent \\ self(), warn_opts) do
-    GenServer.call({:global, {parent, __MODULE__}}, {:analyze, warn_opts}, :infinity)
+  def analyze(parent \\ self(), build_ref, warn_opts) do
+    GenServer.call({:global, {parent, __MODULE__}}, {:analyze, build_ref, warn_opts}, :infinity)
   end
 
-  def analysis_finished(server, status, active_plt, mod_deps, md5, warnings, timestamp) do
+  def analysis_finished(server, status, active_plt, mod_deps, md5, warnings, timestamp, build_ref) do
     GenServer.call(
       server,
       {
@@ -59,10 +60,15 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
         mod_deps,
         md5,
         warnings,
-        timestamp
+        timestamp,
+        build_ref
       },
       :infinity
     )
+  end
+
+  def suggest_contracts(server \\ {:global, {self(), __MODULE__}}, files) do
+    GenServer.call(server, {:suggest_contracts, files}, :infinity)
   end
 
   # Server callbacks
@@ -92,12 +98,13 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   end
 
   def handle_call(
-        {:analysis_finished, _status, active_plt, mod_deps, md5, warnings, timestamp},
+        {:analysis_finished, _status, active_plt, mod_deps, md5, warnings, timestamp, build_ref},
         _from,
         state
       ) do
     diagnostics = to_diagnostics(warnings, state.warn_opts)
-    Server.dialyzer_finished(state.parent, {:ok, diagnostics})
+
+    Server.dialyzer_finished(state.parent, diagnostics, build_ref)
 
     state = %{
       state
@@ -109,7 +116,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     }
 
     state =
-      if state.needs_analysis? do
+      if not is_nil(state.build_ref) do
         do_analyze(state)
       else
         if state.write_manifest_pid, do: Process.exit(state.write_manifest_pid, :kill)
@@ -120,7 +127,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     {:reply, :ok, state}
   end
 
-  def handle_call({:analyze, warn_opts}, _from, state) do
+  def handle_call({:analyze, build_ref, warn_opts}, _from, state) do
     state =
       if Mix.Project.get() do
         JsonRpc.log_message(:info, "[ElixirLS Dialyzer] Checking for stale beam files")
@@ -134,7 +141,8 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
           | warn_opts: warn_opts,
             timestamp: new_timestamp,
             removed_files: removed_files,
-            file_changes: file_changes
+            file_changes: file_changes,
+            build_ref: build_ref
         }
 
         trigger_analyze(state)
@@ -143,6 +151,11 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
       end
 
     {:reply, :ok, state}
+  end
+
+  def handle_call({:suggest_contracts, files}, _from, %{plt: plt} = state) do
+    specs = if is_nil(plt), do: [], else: SuccessTypings.suggest_contracts(plt, files)
+    {:reply, specs, state}
   end
 
   def handle_info({:"ETS-TRANSFER", _, _, _}, state) do
@@ -167,26 +180,25 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
 
   ## Helpers
 
-  defp do_analyze(state) do
+  defp do_analyze(%{write_manifest_pid: write_manifest_pid} = state) do
+    # Cancel writing to the manifest, since we'll end up overwriting it anyway
+    if is_pid(write_manifest_pid), do: Process.exit(write_manifest_pid, :cancelled)
+
     parent = self()
     analysis_pid = spawn_link(fn -> compile(parent, state) end)
 
     %{
       state
       | analysis_pid: analysis_pid,
+        write_manifest_pid: nil,
         file_changes: %{},
         removed_files: [],
-        needs_analysis?: false
+        build_ref: nil
     }
   end
 
-  defp trigger_analyze(%{analysis_pid: nil} = state) do
-    do_analyze(state)
-  end
-
-  defp trigger_analyze(state) do
-    put_in(state.needs_analysis?, true)
-  end
+  defp trigger_analyze(%{analysis_pid: nil} = state), do: do_analyze(state)
+  defp trigger_analyze(state), do: state
 
   defp update_stale(md5, removed_files, file_changes, timestamp) do
     prev_paths = MapSet.new(Map.keys(md5))
@@ -229,7 +241,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
       end)
 
     undialyzable = for {:ok, {file, _, nil}} <- changed_contents, do: file
-    removed_files = Enum.uniq(removed_files ++ removed ++ undialyzable -- changed)
+    removed_files = Enum.uniq(removed_files ++ removed ++ (undialyzable -- changed))
     {removed_files, file_changes}
   end
 
@@ -252,10 +264,11 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
       warnings: warnings,
       timestamp: timestamp,
       removed_files: removed_files,
-      file_changes: file_changes
+      file_changes: file_changes,
+      build_ref: build_ref
     } = state
 
-    {us, {active_plt, mod_deps, md5, warnings, timestamp}} =
+    {us, {active_plt, mod_deps, md5, warnings}} =
       :timer.tc(fn ->
         Task.async_stream(file_changes, fn {file, {content, _}} ->
           write_temp_file(root_path, file, content)
@@ -315,7 +328,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
             {file, hash}
           end
 
-        {active_plt, mod_deps, md5, warnings, timestamp}
+        {active_plt, mod_deps, md5, warnings}
       end)
 
     JsonRpc.log_message(
@@ -323,7 +336,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
       "[ElixirLS Dialyzer] Analysis finished in #{div(us, 1000)} milliseconds"
     )
 
-    analysis_finished(parent, :ok, active_plt, mod_deps, md5, warnings, timestamp)
+    analysis_finished(parent, :ok, active_plt, mod_deps, md5, warnings, timestamp, build_ref)
   end
 
   defp add_warnings(warnings, raw_warnings) do

--- a/apps/language_server/lib/language_server/dialyzer/manifest.ex
+++ b/apps/language_server/lib/language_server/dialyzer/manifest.ex
@@ -15,7 +15,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
       active_plt = load_elixir_plt()
       transfer_plt(active_plt, parent)
 
-      Dialyzer.analysis_finished(parent, :noop, active_plt, %{}, %{}, %{}, nil)
+      Dialyzer.analysis_finished(parent, :noop, active_plt, %{}, %{}, %{}, nil, nil)
     end)
   end
 
@@ -24,29 +24,29 @@ defmodule ElixirLS.LanguageServer.Dialyzer.Manifest do
   end
 
   def write(root_path, active_plt, mod_deps, md5, warnings, timestamp) do
-    manifest_path = manifest_path(root_path)
-
-    plt(
-      info: info,
-      types: types,
-      contracts: contracts,
-      callbacks: callbacks,
-      exported_types: exported_types
-    ) = active_plt
-
-    manifest_data = {
-      @manifest_vsn,
-      mod_deps,
-      md5,
-      warnings,
-      :ets.tab2list(info),
-      :ets.tab2list(types),
-      :ets.tab2list(contracts),
-      :ets.tab2list(callbacks),
-      :ets.tab2list(exported_types)
-    }
-
     spawn(fn ->
+      manifest_path = manifest_path(root_path)
+
+      plt(
+        info: info,
+        types: types,
+        contracts: contracts,
+        callbacks: callbacks,
+        exported_types: exported_types
+      ) = active_plt
+
+      manifest_data = {
+        @manifest_vsn,
+        mod_deps,
+        md5,
+        warnings,
+        :ets.tab2list(info),
+        :ets.tab2list(types),
+        :ets.tab2list(contracts),
+        :ets.tab2list(callbacks),
+        :ets.tab2list(exported_types)
+      }
+
       # Because the manifest file can be several megabytes, we do a write-then-rename
       # to reduce the likelihood of corrupting the manifest
       JsonRpc.log_message(:info, "[ElixirLS Dialyzer] Writing manifest...")

--- a/apps/language_server/lib/language_server/dialyzer/success_typings.ex
+++ b/apps/language_server/lib/language_server/dialyzer/success_typings.ex
@@ -1,0 +1,37 @@
+defmodule ElixirLS.LanguageServer.Dialyzer.SuccessTypings do
+  alias ElixirLS.LanguageServer.SourceFile
+
+  def suggest_contracts(plt, files) do
+    modules =
+      plt
+      |> :dialyzer_plt.all_modules()
+      |> :sets.to_list()
+
+    for mod <- modules,
+        file = source(mod),
+        file in files,
+        {{^mod, fun, arity} = mfa, success_typing} <- success_typings(plt, mod),
+        :dialyzer_plt.lookup_contract(plt, mfa) == :none,
+        line = SourceFile.function_line(mod, fun, arity),
+        is_integer(line),
+        do: {file, line, mfa, success_typing}
+  end
+
+  defp source(module) do
+    if Code.ensure_loaded?(module) do
+      source = module.module_info(:compile)[:source]
+      if is_list(source), do: List.to_string(source)
+    end
+  end
+
+  defp success_typings(plt, mod) do
+    case :dialyzer_plt.lookup_module(plt, mod) do
+      {:value, list} ->
+        for {{module, fun, arity}, ret, args} <- list, into: %{} do
+          t = :erl_types.t_fun(args, ret)
+          sig = :dialyzer_utils.format_sig(t)
+          {{module, fun, arity}, sig}
+        end
+    end
+  end
+end

--- a/apps/language_server/lib/language_server/protocol.ex
+++ b/apps/language_server/lib/language_server/protocol.ex
@@ -156,6 +156,23 @@ defmodule ElixirLS.LanguageServer.Protocol do
     end
   end
 
+  defmacro code_lens_req(id, uri) do
+    quote do
+      request(unquote(id), "textDocument/codeLens", %{
+        "textDocument" => %{"uri" => unquote(uri)}
+      })
+    end
+  end
+
+  defmacro execute_command_req(id, command, arguments) do
+    quote do
+      request(unquote(id), "workspace/executeCommand", %{
+        "command" => unquote(command),
+        "arguments" => unquote(arguments)
+      })
+    end
+  end
+
   # Other utilities
 
   defmacro range(start_line, start_character, end_line, end_character) do

--- a/apps/language_server/lib/language_server/providers/code_lens.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens.ex
@@ -1,0 +1,125 @@
+defmodule ElixirLS.LanguageServer.Providers.CodeLens do
+  @moduledoc """
+  Collects the success typings inferred by Dialyzer, translates the syntax to Elixir, and shows them
+  inline in the editor as @spec suggestions.
+
+  The server, unfortunately, has no way to force the client to refresh the @spec code lenses when new
+  success typings, so we let this request block until we know we have up-to-date results from
+  Dialyzer. We rely on the client being able to await this result while still making other requests
+  in parallel. If the client is unable to perform requests in parallel, the client or user should
+  disable this feature.
+  """
+
+  alias ElixirLS.LanguageServer.{Server, SourceFile}
+  alias Erl2ex.Convert.{Context, ErlForms}
+  alias Erl2ex.Pipeline.{Parse, ModuleData, ExSpec}
+  import ElixirLS.LanguageServer.Protocol
+
+  defmodule ContractTranslator do
+    def translate_contract(fun, contract) do
+      {[%ExSpec{specs: [spec]} | _], _} =
+        "-spec foo#{contract}."
+        |> Parse.string()
+        |> hd()
+        |> elem(0)
+        |> ErlForms.conv_form(%Context{
+          in_type_expr: true,
+          module_data: %ModuleData{}
+        })
+
+      spec
+      |> Macro.postwalk(&tweak_specs/1)
+      |> Macro.to_string()
+      |> String.replace_prefix("foo", to_string(fun))
+    end
+
+    defp tweak_specs({:list, _meta, args}) do
+      case args do
+        [{:{}, _, [{:atom, _, []}, {wild, _, _}]}] when wild in [:_, :any] -> quote do: keyword()
+        list -> list
+      end
+    end
+
+    defp tweak_specs({:nonempty_list, _meta, args}) do
+      case args do
+        [{:any, _, []}] -> quote do: [...]
+        _ -> args ++ quote do: [...]
+      end
+    end
+
+    defp tweak_specs({:%{}, _meta, fields}) do
+      fields =
+        Enum.map(fields, fn
+          {:map_field_exact, _, [key, value]} -> {key, value}
+          {key, value} -> quote do: {optional(unquote(key)), unquote(value)}
+          field -> field
+        end)
+        |> Enum.reject(&match?({{:optional, _, [{:any, _, []}]}, {:any, _, []}}, &1))
+
+      fields
+      |> Enum.find_value(fn
+        {:__struct__, struct_type} when is_atom(struct_type) -> struct_type
+        _ -> nil
+      end)
+      |> case do
+        nil -> {:%{}, [], fields}
+        struct_type -> {{:., [], [struct_type, :t]}, [], []}
+      end
+    end
+
+    # Undo conversion of _ to any() when inside binary spec
+    defp tweak_specs({:<<>>, _, children}) do
+      children =
+        Macro.postwalk(children, fn
+          {:any, _, []} -> quote do: _
+          other -> other
+        end)
+
+      {:<<>>, [], children}
+    end
+
+    defp tweak_specs({:_, _, _}) do
+      quote do: any()
+    end
+
+    defp tweak_specs({:when, [], [spec, substitutions]}) do
+      substitutions = Enum.reject(substitutions, &match?({:_, {:any, _, []}}, &1))
+
+      case substitutions do
+        [] -> spec
+        _ -> {:when, [], [spec, substitutions]}
+      end
+    end
+
+    defp tweak_specs(node) do
+      node
+    end
+  end
+
+  def code_lens(uri, text) do
+    resp =
+      for {_, line, {mod, fun, arity}, contract} <- Server.suggest_contracts(uri),
+          SourceFile.function_def_on_line?(text, line, fun),
+          spec = ContractTranslator.translate_contract(fun, contract) do
+        %{
+          "range" => range(line - 1, 0, line - 1, 0),
+          "command" => %{
+            "title" => "@spec #{spec}",
+            "command" => "spec",
+            "arguments" => [
+              %{
+                "uri" => uri,
+                "mod" => to_string(mod),
+                "fun" => to_string(fun),
+                "arity" => arity,
+                "spec" => spec,
+                "line" => line
+              }
+            ]
+          }
+        }
+      end
+
+    {:ok, resp}
+  end
+end

--- a/apps/language_server/lib/language_server/providers/definition.ex
+++ b/apps/language_server/lib/language_server/providers/definition.ex
@@ -14,6 +14,7 @@ defmodule ElixirLS.LanguageServer.Providers.Definition do
       %Location{file: file, line: line, column: column} ->
         line = line || 0
         column = column || 0
+
         uri =
           case file do
             nil -> uri

--- a/apps/language_server/lib/language_server/providers/execute_command.ex
+++ b/apps/language_server/lib/language_server/providers/execute_command.ex
@@ -1,0 +1,77 @@
+defmodule ElixirLS.LanguageServer.Providers.ExecuteCommand do
+  @moduledoc """
+  Adds a @spec annotation to the document when the user clicks on a code lens.
+  """
+
+  alias ElixirLS.LanguageServer.{JsonRpc, SourceFile}
+  import ElixirLS.LanguageServer.Protocol
+
+  def execute("spec", args, source_files) do
+    [
+      %{
+        "uri" => uri,
+        "mod" => mod,
+        "fun" => fun,
+        "arity" => arity,
+        "spec" => spec,
+        "line" => line
+      }
+    ] = args
+
+    mod = String.to_atom(mod)
+    fun = String.to_atom(fun)
+
+    cur_text = source_files[uri].text
+
+    # In case line has changed since this suggestion was generated, look for the function's current
+    # line number and fall back to the previous line number if we can't guess the new one
+    line =
+      if SourceFile.function_def_on_line?(cur_text, line, fun) do
+        line
+      else
+        new_line = SourceFile.function_line(mod, fun, arity)
+
+        if SourceFile.function_def_on_line?(cur_text, line, fun) do
+          new_line
+        else
+          raise "Function definition has moved since suggestion was generated. " <>
+                  "Try again after file has been recompiled."
+        end
+      end
+
+    cur_line = Enum.at(SourceFile.lines(cur_text), line - 1)
+    [indentation] = Regex.run(Regex.recompile!(~r/^\s*/), cur_line)
+
+    # Attempt to format to fit within the preferred line length, fallback to having it all on one
+    # line if anything fails
+    formatted =
+      try do
+        target_line_length =
+          Mix.Tasks.Format.formatter_opts_for_file(SourceFile.path_from_uri(uri))
+          |> Keyword.get(:line_length, 98)
+
+        target_line_length = target_line_length - String.length(indentation)
+
+        Code.format_string!("@spec #{spec}", line_length: target_line_length)
+        |> IO.iodata_to_binary()
+        |> String.split("\n")
+        |> Enum.map(&(indentation <> &1))
+        |> Enum.join("\n")
+        |> Kernel.<>("\n")
+      rescue
+        _ ->
+          "#{indentation}@spec #{spec}\n"
+      end
+
+    JsonRpc.send_request("workspace/applyEdit", %{
+      "label" => "Add @spec to #{mod}.#{fun}/#{arity}",
+      "edit" => %{
+        "changes" => %{
+          uri => [%{"range" => range(line - 1, 0, line - 1, 0), "newText" => formatted}]
+        }
+      }
+    })
+
+    {:ok, nil}
+  end
+end

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -39,7 +39,8 @@ defmodule ElixirLS.LanguageServer.Mixfile do
     [
       {:elixir_ls_utils, in_umbrella: true},
       {:elixir_sense, github: "msaraiva/elixir_sense"},
-      {:forms, "~> 0.0.1"}
+      {:forms, "~> 0.0.1"},
+      {:erl2ex, github: "dazuma/erl2ex"}
     ]
   end
 end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -108,17 +108,6 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     }
   end
 
-  test "responses are sent in order of request regardless of completion order", %{server: server} do
-    for id <- 1..3, do: Server.receive_packet(server, hover_req(id, "file:///file.ex", 1, 1))
-    for id <- 3..1, do: Server.receive_packet(server, cancel_request(id))
-
-    for id <- 1..3 do
-      receive do
-        message -> assert %{"id" => ^id, "error" => %{"code" => -32800}} = message
-      end
-    end
-  end
-
   test "formatter", %{server: server} do
     in_fixture(__DIR__, "formatter", fn ->
       uri = Path.join([root_uri(), "file.ex"])

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "distillery": {:hex, :distillery, "1.4.0", "d633cd322c8efa0428082b00b7f902daf8caa166d45f9022bbc19a896d2e1e56", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
   "elixir_sense": {:git, "https://github.com/msaraiva/elixir_sense.git", "bc627b7ba199ab4d365d18512571c1cf5d565cad", []},
+  "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "1b8c7d026168c0e81ca1409ff76030f85ff3af8b", []},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.6.3", "894bf9254890a4aac1d1165da08145a72700ff42d8cb6ce8195a584cb2a4b374", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},


### PR DESCRIPTION
This required more changes than expected:

* The server can't tell the client when to update code lenses, so instead, we have to block until we know that Dialyzer's analysis is up-to-date. That means the request has to block potentially indefinitely. Older versions of the Language Server Protocol specified that requests must be responded to in the order they are received, but that restriction has been relaxed recently, so we no longer hold responses until all previous requests have been handled and we allow a code lens request to block for as long as is neccessary.

* Dialyzer now includes the build ref of the build it's analyzing in its response to the server so we can tell if it's up-to-date with the latest build.

* To make Dialyzer snappier, when writing the manifest, the work of converting the PLT's ETS tables to lists has been moved into the separate process.