### PR TITLE
Added matcher for setExceptionBreakpoints request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ erl_crash.dump
 
 # Run release.sh to generate this release folder
 /release
+
+# Also ignore temp files created during testing
+**/test/tmp

--- a/apps/debugger/lib/debugger/protocol.ex
+++ b/apps/debugger/lib/debugger/protocol.ex
@@ -2,7 +2,7 @@ defmodule ElixirLS.Debugger.Protocol do
   @moduledoc """
   Macros for VS Code debug protocol requests
 
-  These macros can be used for pattern matching against incoming requests, or for creating request 
+  These macros can be used for pattern matching against incoming requests, or for creating request
   messages for use in tests.
   """
   import ElixirLS.Debugger.Protocol.Basic
@@ -32,6 +32,12 @@ defmodule ElixirLS.Debugger.Protocol do
         "source" => unquote(source),
         "breakpoints" => unquote(breakpoints)
       })
+    end
+  end
+
+  defmacro set_exception_breakpoints_req(seq) do
+    quote do
+      request(unquote(seq), "setExceptionBreakpoints")
     end
   end
 

--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -168,6 +168,10 @@ defmodule ElixirLS.Debugger.Server do
     {%{"breakpoints" => breakpoints_json}, state}
   end
 
+  defp handle_request(set_exception_breakpoints_req(_), state) do
+    {%{}, state}
+  end
+
   defp handle_request(configuration_done_req(_), state) do
     server = :erlang.process_info(self())[:registered_name] || self()
     :int.auto_attach([:break], {__MODULE__, :breakpoint_reached, [server]})

--- a/apps/debugger/test/debugger_test.exs
+++ b/apps/debugger/test/debugger_test.exs
@@ -53,11 +53,14 @@ defmodule ElixirLS.Debugger.ServerTest do
         response(_, 3, "setBreakpoints", %{"breakpoints" => [%{"verified" => true}]})
       )
 
-      Server.receive_packet(server, request(4, "configurationDone", %{}))
-      assert_receive(response(_, 4, "configurationDone", %{}))
+      Server.receive_packet(server, request(4, "setExceptionBreakpoints", %{"filters" => []}))
+      assert_receive(response(_, 4, "setExceptionBreakpoints", %{}))
 
-      Server.receive_packet(server, request(5, "threads", %{}))
-      assert_receive(response(_, 5, "threads", %{"threads" => threads}))
+      Server.receive_packet(server, request(5, "configurationDone", %{}))
+      assert_receive(response(_, 5, "configurationDone", %{}))
+
+      Server.receive_packet(server, request(6, "threads", %{}))
+      assert_receive(response(_, 6, "threads", %{"threads" => threads}))
       # ensure thread ids are unique
       thread_ids = Enum.map(threads, & &1["id"])
       assert Enum.count(Enum.uniq(thread_ids)) == Enum.count(thread_ids)
@@ -68,9 +71,9 @@ defmodule ElixirLS.Debugger.ServerTest do
                        "threadId" => thread_id
                      })
 
-      Server.receive_packet(server, stacktrace_req(6, thread_id))
+      Server.receive_packet(server, stacktrace_req(7, thread_id))
 
-      assert_receive response(_, 6, "stackTrace", %{
+      assert_receive response(_, 7, "stackTrace", %{
                        "totalFrames" => 1,
                        "stackFrames" => [
                          %{
@@ -86,9 +89,9 @@ defmodule ElixirLS.Debugger.ServerTest do
 
       assert String.ends_with?(path, "/lib/mix_project.ex")
 
-      Server.receive_packet(server, scopes_req(7, frame_id))
+      Server.receive_packet(server, scopes_req(8, frame_id))
 
-      assert_receive response(_, 7, "scopes", %{
+      assert_receive response(_, 8, "scopes", %{
                        "scopes" => [
                          %{
                            "expensive" => false,
@@ -107,9 +110,9 @@ defmodule ElixirLS.Debugger.ServerTest do
                        ]
                      })
 
-      Server.receive_packet(server, vars_req(8, vars_id))
+      Server.receive_packet(server, vars_req(9, vars_id))
 
-      assert_receive response(_, 8, "variables", %{
+      assert_receive response(_, 9, "variables", %{
                        "variables" => [
                          %{
                            "name" => _,
@@ -120,8 +123,8 @@ defmodule ElixirLS.Debugger.ServerTest do
                        ]
                      })
 
-      Server.receive_packet(server, continue_req(9, thread_id))
-      assert_receive response(_, 9, "continue", %{"allThreadsContinued" => false})
+      Server.receive_packet(server, continue_req(10, thread_id))
+      assert_receive response(_, 10, "continue", %{"allThreadsContinued" => false})
 
       assert_receive(event(_, "exited", %{"exitCode" => 0}))
       assert_receive(event(_, "terminated", %{"restart" => false}))


### PR DESCRIPTION
It looks like vscode will now send out a setExceptionBreakpoints request, even if exceptionBreakpointFilters is not defined, or is set to an empty array. 

This causes the debugger to crash due to no handle_request function matching. 

I've followed the existing examples to add a simple handler that effectively ignores the request (as far as I can tell). I've tested the result in the latest code insiders (1.29.0-insider) and it works for me, not sure if I've covered everything I need to though, so happy to be corrected.