### PR TITLE
'workspace/didChangeConfiguration' should handle non-map type

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -226,10 +226,12 @@ defmodule ElixirLS.LanguageServer.Server do
     end
   end
 
-  defp handle_notification(did_change_configuration(settings), state) do
-    settings = Map.get(settings, "elixirLS", %{})
+  defp handle_notification(did_change_configuration(%{"elixirLS" => settings}), state)
+       when is_map(settings) do
     set_settings(state, settings)
   end
+
+  defp handle_notification(did_change_configuration(_settings), state), do: state
 
   defp handle_notification(notification("exit"), state) do
     code = if state.received_shutdown?, do: 0, else: 1


### PR DESCRIPTION
Editor plugin I'm using passes `null` as the initial `setting` value for `workspace/didChangeConfiguration`, causing the server to crash. 
Fix just ignores the non-map values