### PR TITLE
ElixirLS in WSL started from native Windows app support

### DIFF
--- a/apps/elixir_ls_utils/priv/language_server_wsl.bat
+++ b/apps/elixir_ls_utils/priv/language_server_wsl.bat
@@ -1,0 +1,3 @@
+@echo off & setlocal enabledelayedexpansion
+
+bash -lc "./language_server.sh"

--- a/apps/language_server/lib/language_server/source_file.ex
+++ b/apps/language_server/lib/language_server/source_file.ex
@@ -51,14 +51,15 @@ defmodule ElixirLS.LanguageServer.SourceFile do
   def path_to_uri(path) do
     uri_path =
       path
-      |> path_from_wsl() # if in WSL translate to Windows path
       |> Path.expand()
+      |> path_from_wsl() # if in WSL translate to Windows path
       |> URI.encode()
       |> String.replace(":", "%3A")
 
-    case :os.type() do
-      {:win32, _} -> "file:///" <> uri_path
-      _ -> "file://" <> uri_path
+    cond do
+      :win32 == elem(:os.type(), 0)                         -> "file:///" <> uri_path
+      in_wsl?() && Regex.match?(~r/^[a-z]%3A/i, uri_path)   -> "file:///" <> uri_path
+      true                                                  -> "file://" <> uri_path
     end
   end
 


### PR DESCRIPTION
WSL mounts Windows drives root (C:, D: etc) via drvfs binds (to /mnt by default but it can be changed via `/etc/wsl.conf`). So it is possible to translate paths analyzing mounts list. `path_to_uri` and `path_from_uri` functions adopted for such translation if it detects WSL. This behavior works on WSL only and if mounts like C: on /c exist only.

language_server_wsl.bat with simple `bash -lc "./language_server.sh" command also added. It should be enough to start ElixirLS within WSL, but vscode-elixir-ls plugin should be adopted as well.

This PR closes #153 as well.