### PR TITLE
Change Dialyzer's `analyze` message to be a GenServer notification in…

### DIFF
--- a/apps/language_server/lib/language_server/dialyzer.ex
+++ b/apps/language_server/lib/language_server/dialyzer.ex
@@ -64,7 +64,7 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
   end
 
   def analyze(parent \\ self(), build_ref, warn_opts) do
-    GenServer.call({:global, {parent, __MODULE__}}, {:analyze, build_ref, warn_opts}, :infinity)
+    GenServer.cast({:global, {parent, __MODULE__}}, {:analyze, build_ref, warn_opts})
   end
 
   def analysis_finished(server, status, active_plt, mod_deps, md5, warnings, timestamp, build_ref) do
@@ -144,35 +144,37 @@ defmodule ElixirLS.LanguageServer.Dialyzer do
     {:reply, :ok, state}
   end
 
-  def handle_call({:analyze, build_ref, warn_opts}, _from, state) do
-    state =
-      if Mix.Project.get() do
-        JsonRpc.log_message(:info, "[ElixirLS Dialyzer] Checking for stale beam files")
-        new_timestamp = adjusted_timestamp()
-
-        {removed_files, file_changes} =
-          update_stale(state.md5, state.removed_files, state.file_changes, state.timestamp)
-
-        state = %{
-          state
-          | warn_opts: warn_opts,
-            timestamp: new_timestamp,
-            removed_files: removed_files,
-            file_changes: file_changes,
-            build_ref: build_ref
-        }
-
-        trigger_analyze(state)
-      else
-        state
-      end
-
-    {:reply, :ok, state}
-  end
-
   def handle_call({:suggest_contracts, files}, _from, %{plt: plt} = state) do
     specs = if is_nil(plt), do: [], else: SuccessTypings.suggest_contracts(plt, files)
     {:reply, specs, state}
+  end
+
+  def handle_cast({:analyze, build_ref, warn_opts}, state) do
+    state =
+      ElixirLS.LanguageServer.Build.with_build_lock(fn ->
+        if Mix.Project.get() do
+          JsonRpc.log_message(:info, "[ElixirLS Dialyzer] Checking for stale beam files")
+          new_timestamp = adjusted_timestamp()
+
+          {removed_files, file_changes} =
+            update_stale(state.md5, state.removed_files, state.file_changes, state.timestamp)
+
+          state = %{
+            state
+            | warn_opts: warn_opts,
+              timestamp: new_timestamp,
+              removed_files: removed_files,
+              file_changes: file_changes,
+              build_ref: build_ref
+          }
+
+          trigger_analyze(state)
+        else
+          state
+        end
+      end)
+
+    {:noreply, state}
   end
 
   def handle_info({:"ETS-TRANSFER", _, _, _}, state) do


### PR DESCRIPTION
…stead of request and grab build lock while stale-checking beams

Up till now, the reason that the `analyze` is triggered with a GenServer `call` instead of `cast` is just so that a build doesn't happen concurrently (since the build can delete beam files while the Dialyzer server tries to stale-check them). There are other places where the global state changes caused by builds are a problem too, and we added a global "build lock" that processes can grab to avoid this sort of thing.

I'm turning "analyze" into a GenServer cast, which allows the main language server to continue servicing requests. The Dialyzer server will grab the build lock while it stale-checks the beam files so it only blocks builds, not the main language server. This also makes it more robust because an exception or exit during analyze won't kill the main language server and the supervisor can restart the Dialyzer server.