### PR TITLE
Prevent @spec codelens for implemented callbacks

### DIFF
--- a/apps/language_server/lib/language_server/providers/code_lens.ex
+++ b/apps/language_server/lib/language_server/providers/code_lens.ex
@@ -100,6 +100,7 @@ defmodule ElixirLS.LanguageServer.Providers.CodeLens do
     resp =
       for {_, line, {mod, fun, arity}, contract} <- Server.suggest_contracts(uri),
           SourceFile.function_def_on_line?(text, line, fun),
+          SourceFile.function_requires_spec?(text, line, fun),
           spec = ContractTranslator.translate_contract(fun, contract) do
         %{
           "range" => range(line - 1, 0, line - 1, 0),


### PR DESCRIPTION
When callbacks are marked with `@impl (true | mod)` their
typespec/contract is inferred from the specified implementation.

In [this forum post](https://elixirforum.com/t/does-dialyzer-check-behaviours-and-callbacks/2101) @fishcakez mentions this:

>  In general it does not make sense to infer the callback as the spec for explicit calls because the callback implementation will likely have a subset of the callback definition. For example with GenServer the state can be term but it is likely required to be a struct.
> 
> Normally for callback implementations the code is never called directly and so dialyzer can’t infer it is called. Often it will be called using a variable: mod.callback_fun(arg)

Given a very generic behaviours such as GenServer where the type of the state is unknown, it might be better to introduce a custom spec, but in the case of less generic behaviours, inferring seems the right thing to do.

Anyway, very much debatable if this is the right thing to do, and after having implemented this change I'm less certain this is a good change. Can we discuss the pros/cons of this?