### PR TITLE
Update OTP required versions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Elixir Language Server provides a server that runs in the background, provid
 
 ## Features
 
-- Debugger support (requires Erlang >= OTP 19)
+- Debugger support
 - Automatic, incremental Dialyzer analysis (requires Erlang OTP 20)
 - Automatic inline suggestion of @specs based on Dialyzer's inferred success typings
 - Inline reporting of build warnings and errors
@@ -25,7 +25,7 @@ Elixir:
 
 Erlang:
 
-- OTP 18 minimum
+- OTP 19 minimum
 - \>= OTP 20 recommended
 
 You may want to install Elixir and Erlang from source, using the [kiex](https://github.com/taylor/kiex) and [kerl](https://github.com/kerl/kerl) tools. This will let you go-to-definition for core Elixir and Erlang modules.


### PR DESCRIPTION
Since the bump to Elixir 1.7+ in the project it will only run with OTP 19+. So, no need to warn about lower versions.