### PR TITLE
Requesting didSave notification in server capabilities

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -429,7 +429,11 @@ defmodule ElixirLS.LanguageServer.Server do
 
   defp server_capabilities do
     %{
-      "textDocumentSync" => 2,
+      "textDocumentSync" => %{
+        "change" => 2,
+        "openClose" => true,
+        "save" => true
+      },
       "hoverProvider" => true,
       "completionProvider" => %{"triggerCharacters" => Completion.trigger_characters()},
       "definitionProvider" => true,


### PR DESCRIPTION
Since the server is using didSave notification, it needs to specifically ask for
it in the server capabilities. In VS Code it works fine without this, because
the editor sends the notification regardless of what server advertises. However,
other editors, such as Emacs with lsp-mode, break without this config.

I run into this issue in Emacs lsp-mode (https://github.com/emacs-lsp/lsp-ui/issues/300), when I added the `%{"save" => true}` to the server capabilities in the client, it fixed the problem.