### PR TITLE
Point new elixir_sense repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you're packaging these archives in an IDE plugin, make sure to build using Er
 
 ## Acknowledgements and related projects
 
-ElixirLS isn't the first frontend-independent server for Elixir language support. The original was [Alchemist Server](https://github.com/tonini/alchemist-server/), which powers the [Alchemist](https://github.com/tonini/alchemist.el) plugin for Emacs. Another project, [Elixir Sense](https://github.com/msaraiva/elixir_sense), builds upon Alchemist and powers the [Elixir plugin for Atom](https://github.com/msaraiva/atom-elixir) as well as another VS Code plugin, [VSCode Elixir](https://github.com/fr1zle/vscode-elixir). ElixirLS uses Elixir Sense for several code insight features. Credit for those projects goes to their respective authors.
+ElixirLS isn't the first frontend-independent server for Elixir language support. The original was [Alchemist Server](https://github.com/tonini/alchemist-server/), which powers the [Alchemist](https://github.com/tonini/alchemist.el) plugin for Emacs. Another project, [Elixir Sense](https://github.com/elixir-lsp/elixir_sense), builds upon Alchemist and powers the [Elixir plugin for Atom](https://github.com/msaraiva/atom-elixir) as well as another VS Code plugin, [VSCode Elixir](https://github.com/fr1zle/vscode-elixir). ElixirLS uses Elixir Sense for several code insight features. Credit for those projects goes to their respective authors.
 
 ## License
 

--- a/apps/debugger/mix.exs
+++ b/apps/debugger/mix.exs
@@ -40,6 +40,6 @@ defmodule ElixirLS.Debugger.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:elixir_sense, github: "msaraiva/elixir_sense"}, {:elixir_ls_utils, in_umbrella: true}]
+    [{:elixir_sense, github: "elixir-lsp/elixir_sense"}, {:elixir_ls_utils, in_umbrella: true}]
   end
 end

--- a/apps/language_server/mix.exs
+++ b/apps/language_server/mix.exs
@@ -38,7 +38,7 @@ defmodule ElixirLS.LanguageServer.Mixfile do
   defp deps do
     [
       {:elixir_ls_utils, in_umbrella: true},
-      {:elixir_sense, github: "msaraiva/elixir_sense"},
+      {:elixir_sense, github: "elixir-lsp/elixir_sense"},
       {:forms, "~> 0.0.1"},
       {:erl2ex, github: "dazuma/erl2ex"},
       {:dialyxir, "~> 1.0.0-rc.2"}

--- a/mix.lock
+++ b/mix.lock
@@ -5,7 +5,7 @@
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "distillery": {:hex, :distillery, "1.4.0", "d633cd322c8efa0428082b00b7f902daf8caa166d45f9022bbc19a896d2e1e56", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
-  "elixir_sense": {:git, "https://github.com/msaraiva/elixir_sense.git", "3bf4be374abfcd0cafa543fa3782b9a75333246b", []},
+  "elixir_sense": {:git, "https://github.com/elixir-lsp/elixir_sense.git", "3bf4be374abfcd0cafa543fa3782b9a75333246b", []},
   "erl2ex": {:git, "https://github.com/dazuma/erl2ex.git", "1b8c7d026168c0e81ca1409ff76030f85ff3af8b", []},
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},


### PR DESCRIPTION
According to [README in msaraiva/elixir_sense](https://github.com/msaraiva/elixir_sense/tree/15bf8a5d4ea55ced2d76e5f41620c769cf125c82#note-this-project-has-been-moved-to-httpsgithubcomelixir-lspelixir_sense-any-issuepr-should-be-submitted-to-the-new-repo),
the repository has been moved to [elixir-lsp/elixir_sense](https://github.com/elixir-lsp/elixir_sense).

