### PR TITLE
launch debugger faster,  when there are many exclude_modules .

### DIFF
--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -528,8 +528,8 @@ defmodule ElixirLS.Debugger.Server do
   end
 
   defp interpretable?(module, exclude_modules) do
-    :int.interpretable(module) == true and !:code.is_sticky(module) and module != __MODULE__ and
-      module not in exclude_modules
+    module not in exclude_modules and :int.interpretable(module) == true and
+      !:code.is_sticky(module) and module != __MODULE__
   end
 
   defp check_erlang_version do


### PR DESCRIPTION
Launch debugger faster.

*  `:int.interpretable(module) == true and !:code.is_sticky(module)` is very heavy operation.
*  By excluding modules at first, we can avoid this operation as possible as we can. And debugger is launched faster.
    *  ex) I always use elixir-ls by excluding all deps related modules.