### PR TITLE
imp workaround. "--no-halt" option does not work in Elixir 1.9.x

### DIFF
--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -565,6 +565,10 @@ defmodule ElixirLS.Debugger.Server do
 
   defp launch_task(task, args) do
     Mix.Task.run(task, args)
+    if "--no-halt" in args do
+      # workaround. "--no-halt"  does not work in Elixir 1.9.x
+      Process.sleep(:infinity)
+    end
   end
 
   # Interpreting modules defined in .exs files requires that we first load the file and save any


### PR DESCRIPTION
From Elixir 1.9.x,  --no-halt option does not work.
As a result, we cannot debug application which launch with --no-halt option.
I implemented workaround.

