### PR TITLE
Add Neovim coc.nvim compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ You may want to install Elixir and Erlang from source, using the [kiex](https://
 | IDE      | Plugin                                                                        | Support                                        |
 | -------- | ----------------------------------------------------------------------------- | ---------------------------------------------- |
 | VS Code  | [JakeBecker/vscode-elixir-ls](https://github.com/JakeBecker/vscode-elixir-ls) | Supports all ElixirLS features                 |
+| Neovim   | [coc.nvim](https://github.com/neoclide/coc.nvim)                              | Supports all ElixirLS features except debugger |
 | Atom IDE | [JakeBecker/ide-elixir](https://github.com/JakeBecker/ide-elixir)             | Does not support debugger or @spec suggestions |
 | Vim      | [ALE](https://github.com/w0rp/ale)                                            | Does not support debugger or @spec suggestions |
 | Emacs    | [lsp-mode](https://github.com/emacs-lsp/lsp-mode) | Supports debugger via [dap-mode](https://github.com/yyoncho/dap-mode) |


### PR DESCRIPTION
Using coc.nvim support all the ElixirLS features except the debugger

https://github.com/neoclide/coc.nvim/wiki/Language-servers#elixir

coc.nvim is compatible with vim8 but the functionality of `@spec`
suggestions only works on neovim.

![image](https://user-images.githubusercontent.com/1911813/69512323-9b256000-0f11-11ea-9515-b4924201f536.png)

