### PR TITLE
fix. some modules  cannot be loaded and  debugger is crashed.

### DIFF
--- a/apps/debugger/lib/debugger/server.ex
+++ b/apps/debugger/lib/debugger/server.ex
@@ -524,7 +524,15 @@ defmodule ElixirLS.Debugger.Server do
     |> Path.wildcard()
     |> Enum.map(&(Path.basename(&1, ".beam") |> String.to_atom()))
     |> Enum.filter(&interpretable?(&1, exclude_modules))
-    |> Enum.map(&:int.ni(&1))
+    |> Enum.map(fn module ->
+      IO.puts("loading #{module}")
+      try do
+        :int.ni(module)
+        IO.puts("success")
+      rescue
+        error -> IO.puts("failure #{Exception.message(error)}")
+      end
+    end)
   end
 
   defp interpretable?(module, exclude_modules) do


### PR DESCRIPTION
### Modification

handle exception from :int.ni() and continue debugging.

### ISSUE

In debugging, :int.ni() raise exception and crashed when loading some module such as "Elixir.Bcrypt.Base"

https://github.com/JakeBecker/elixir-ls/issues/148
https://github.com/JakeBecker/vscode-elixir-ls/issues/25
https://github.com/JakeBecker/vscode-elixir-ls/issues/105
