### PR TITLE
Added support for shutdown notification

### DIFF
--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -244,6 +244,10 @@ defmodule ElixirLS.LanguageServer.Server do
     set_settings(state, new_settings)
   end
 
+  defp handle_notification(notification("shutdown"), state) do
+    %{state | received_shutdown?: true}
+  end
+
   defp handle_notification(notification("exit"), state) do
     code = if state.received_shutdown?, do: 0, else: 1
     System.halt(code)
@@ -325,8 +329,11 @@ defmodule ElixirLS.LanguageServer.Server do
     {:ok, %{"capabilities" => server_capabilities()}, state}
   end
 
+  # NOTE: This doesn't seem to match spec
+  # https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md#shutdown-request
   defp handle_request(request(_id, "shutdown", _params), state) do
-    {:ok, nil, %{state | received_shutdown?: true}}
+    state = handle_request(notification("shutdown"), state)
+    {:ok, nil, state}
   end
 
   defp handle_request(definition_req(_id, uri, line, character), state) do

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -108,6 +108,11 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     }
   end
 
+  test "requests shutdown", %{server: server} do
+    Server.receive_packet(server, notification("shutdown"))
+    assert %{received_shutdown?: true} = :sys.get_state(server)
+  end
+
   # TODO: Fix this test for the incremental formatter
   test "formatter", %{server: server} do
     in_fixture(__DIR__, "formatter", fn ->


### PR DESCRIPTION
As described in issues #208 and #189, it appears that the following notification isn't handled:

```
%{"id" => 2, "jsonrpc" => "2.0", "method" => "shutdown"}
```

This PR adds support for this notification, and tests to support.  Added note to @JakeBecker - might want to check if `apps/language_server/lib/language_server/server.ex:332` is still necessary.  At least on my brief review of https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md#shutdown-request, it didn't look like that was part of the spec (which was apparently causing the error).