### PR TITLE
Fix requestMessage doesnt seem to match spec

### DIFF
--- a/apps/language_server/lib/language_server/json_rpc.ex
+++ b/apps/language_server/lib/language_server/json_rpc.ex
@@ -27,6 +27,16 @@ defmodule ElixirLS.LanguageServer.JsonRpc do
     end
   end
 
+  defmacro request(id, method) do
+    quote do
+      %{
+        "id" => unquote(id),
+        "method" => unquote(method),
+        "jsonrpc" => "2.0"
+      }
+    end
+  end
+
   defmacro request(id, method, params) do
     quote do
       %{

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -244,10 +244,6 @@ defmodule ElixirLS.LanguageServer.Server do
     set_settings(state, new_settings)
   end
 
-  defp handle_notification(notification("shutdown"), state) do
-    %{state | received_shutdown?: true}
-  end
-
   defp handle_notification(notification("exit"), state) do
     code = if state.received_shutdown?, do: 0, else: 1
     System.halt(code)
@@ -329,11 +325,8 @@ defmodule ElixirLS.LanguageServer.Server do
     {:ok, %{"capabilities" => server_capabilities()}, state}
   end
 
-  # NOTE: This doesn't seem to match spec
-  # https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md#shutdown-request
   defp handle_request(request(_id, "shutdown", _params), state) do
-    state = handle_request(notification("shutdown"), state)
-    {:ok, nil, state}
+    {:ok, nil, %{state | received_shutdown?: true}}
   end
 
   defp handle_request(definition_req(_id, uri, line, character), state) do

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -244,6 +244,10 @@ defmodule ElixirLS.LanguageServer.Server do
     set_settings(state, new_settings)
   end
 
+  defp handle_notification(notification("shutdown"), state) do
+    %{state | received_shutdown?: true}
+  end
+
   defp handle_notification(notification("exit"), state) do
     code = if state.received_shutdown?, do: 0, else: 1
     System.halt(code)
@@ -325,8 +329,11 @@ defmodule ElixirLS.LanguageServer.Server do
     {:ok, %{"capabilities" => server_capabilities()}, state}
   end
 
+  # NOTE: This doesn't seem to match spec
+  # https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md#shutdown-request
   defp handle_request(request(_id, "shutdown", _params), state) do
-    {:ok, nil, %{state | received_shutdown?: true}}
+    state = handle_request(notification("shutdown"), state)
+    {:ok, nil, state}
   end
 
   defp handle_request(definition_req(_id, uri, line, character), state) do

--- a/apps/language_server/lib/language_server/server.ex
+++ b/apps/language_server/lib/language_server/server.ex
@@ -123,22 +123,11 @@ defmodule ElixirLS.LanguageServer.Server do
   end
 
   def handle_cast({:receive_packet, request(id, _, _) = packet}, state) do
-    state =
-      case handle_request(packet, state) do
-        {:ok, result, state} ->
-          JsonRpc.respond(id, result)
-          state
+    {:noreply, handle_request_packet(id, packet, state)}
+  end
 
-        {:error, type, msg, state} ->
-          JsonRpc.respond_with_error(id, type, msg)
-          state
-
-        {:async, fun, state} ->
-          {pid, _ref} = handle_request_async(id, fun)
-          %{state | requests: Map.put(state.requests, id, pid)}
-      end
-
-    {:noreply, state}
+  def handle_cast({:receive_packet, request(id, method)}, state) do
+    {:noreply, handle_request_packet(id, request(id, method, nil), state)}
   end
 
   def handle_cast({:receive_packet, notification(_) = packet}, state) do
@@ -303,6 +292,22 @@ defmodule ElixirLS.LanguageServer.Server do
     state
   end
 
+  defp handle_request_packet(id, packet, state) do
+    case handle_request(packet, state) do
+      {:ok, result, state} ->
+        JsonRpc.respond(id, result)
+        state
+
+      {:error, type, msg, state} ->
+        JsonRpc.respond_with_error(id, type, msg)
+        state
+
+      {:async, fun, state} ->
+        {pid, _ref} = handle_request_async(id, fun)
+        %{state | requests: Map.put(state.requests, id, pid)}
+    end
+  end
+
   defp handle_request(initialize_req(_id, root_uri, client_capabilities), state) do
     show_version_warnings()
 
@@ -413,7 +418,15 @@ defmodule ElixirLS.LanguageServer.Server do
     {:async, fn -> ExecuteCommand.execute(command, args, state.source_files) end, state}
   end
 
+  defp handle_request(request(_, _) = req, state) do
+    handle_unmatched_request(req, state)
+  end
+
   defp handle_request(request(_, _, _) = req, state) do
+    handle_unmatched_request(req, state)
+  end
+
+  defp handle_unmatched_request(req, state) do
     IO.inspect(req, label: "Unmatched request")
     {:error, :invalid_request, nil, state}
   end

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -108,6 +108,11 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     }
   end
 
+  test "requests shutdown", %{server: server} do
+    Server.receive_packet(server, notification("shutdown"))
+    assert %{received_shutdown?: true} = :sys.get_state(server)
+  end
+
   # TODO: Fix this test for the incremental formatter
   test "formatter", %{server: server} do
     in_fixture(__DIR__, "formatter", fn ->

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -108,6 +108,11 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     }
   end
 
+  test "requests shutdown", %{server: server} do
+    Server.receive_packet(server, request(1, "shutdown"))
+    assert %{received_shutdown?: true} = :sys.get_state(server)
+  end
+
   # TODO: Fix this test for the incremental formatter
   test "formatter", %{server: server} do
     in_fixture(__DIR__, "formatter", fn ->

--- a/apps/language_server/test/server_test.exs
+++ b/apps/language_server/test/server_test.exs
@@ -108,11 +108,6 @@ defmodule ElixirLS.LanguageServer.ServerTest do
     }
   end
 
-  test "requests shutdown", %{server: server} do
-    Server.receive_packet(server, notification("shutdown"))
-    assert %{received_shutdown?: true} = :sys.get_state(server)
-  end
-
   # TODO: Fix this test for the incremental formatter
   test "formatter", %{server: server} do
     in_fixture(__DIR__, "formatter", fn ->


### PR DESCRIPTION
In the LSP spec for `requestMessage`, the `params` key is optional.  However, the code seems to only expect the 3 arity variant.  This patch allows both the 2 arity and 3 arity variants, so that the `shutdown` requests will work (which doesn't include a `params` key).

Fixes #209 

See also:
https://microsoft.github.io/language-server-protocol/specifications/specification-current/#requestMessage